### PR TITLE
#82 - 🔧 Adicionado alteração do status na resposta do recurso

### DIFF
--- a/Controllers/Resources.php
+++ b/Controllers/Resources.php
@@ -9,6 +9,11 @@ use \Saude\Entities\Resources as EntitiesResources;
 
 class Resources extends \MapasCulturais\Controller{
 
+    const STATUS_APPROVED = 10;
+    const STATUS_WAITLIST = 8;
+    const STATUS_NOTAPPROVED = 3;
+    const STATUS_INVALID = 2;
+
     function GET_index() {
         //$this->render('resources');
         ini_set('display_errors', 1);
@@ -68,9 +73,11 @@ class Resources extends \MapasCulturais\Controller{
     }
 
     function PUT_replyResource() {
+        
         if(
             empty($this->postData['resource_reply']) || 
-            empty($this->postData['resource_status']) ){
+            empty($this->postData['resource_status']) || 
+            empty($this->postData['status'])){
             $this->json(['title' => 'Erro','message' => 'Todos os campos deve ser preenchidos', 'type' => 'error'], 500);
         }
         $app = App::i();
@@ -89,6 +96,13 @@ class Resources extends \MapasCulturais\Controller{
             if($this->putData['new_consolidated_result'] > $max) {
                 $this->json(['title' => 'Ops!','message' => 'A nova nota não pode ser maior que a nota máxima', 'type' => 'error'], 401);
             }else{
+                
+                if(isset($this->putData['status']) && $this->putData['status'] == '1') {
+                    $dql = "UPDATE MapasCulturais\Entities\Registration r 
+                    SET r.status = 10 WHERE r.id = {$reg->id}";
+                    $query      = $app->em->createQuery($dql);
+                    $upStatus   = $query->getResult();
+                }
                 $reg->consolidatedResult = $this->putData['new_consolidated_result'];
                 $app->em->persist($reg);
             }

--- a/assets/js/ng.resource.js
+++ b/assets/js/ng.resource.js
@@ -255,6 +255,7 @@ function publishResource(opportunity) {
             });
             $("#div-publish").hide();
             $("#div-alert-publish").show();
+            location.reload();
         }
     });
 }

--- a/layouts/parts/modals/form-reply-resource.php
+++ b/layouts/parts/modals/form-reply-resource.php
@@ -47,6 +47,12 @@
             step=".01"
             name="new_consolidated_result" id="new_consolidated_result"
             class="form-control">
+            <label for="">Status do Candidato</label>
+            <select name="status" id="" class="form-control">
+                <option value="">--Selecione--</option>
+                <option value="1">Habilitar próxima fase</option>
+                <option value="2">Manter Status</option>
+            </select>
         </div>
         <hr>
         <button data-remodal-action="cancel" class="btn btn-default" title="Sair da resposta">


### PR DESCRIPTION
**Autores**
@FernandaNascimento26 e @Junior-Shyko 

**Issue**
#82 

**Contexto**
No formulário de resposta do recurso o avaliador ou mesmo administrador deverá selecionar o status do candidato, mantendo o mesmo status ou habilitando para o próxima fase.

**Teste**
Conferir o checkdesk da issue #82 