### PR TITLE
#107 - 🚸 Ajustando valor de escrita quando for adm de um grupo

### DIFF
--- a/layouts/parts/agent/related-spacos.php
+++ b/layouts/parts/agent/related-spacos.php
@@ -12,8 +12,16 @@
                 <?php foreach ($groups as $group): ?>
                     
                     <li class="widget-list-item">
-                        <?php echo $group['group']; ?> <?php \MapasCulturais\i::_e("em"); ?> 
-                        <a href="<?php echo $group['url']; ?>" style="display: initial;">
+                        <?php 
+                        
+                        if($group['group'] == 'group-admin'){
+                            \MapasCulturais\i::_e("Admininstrador(a)");
+                        }else{
+                            echo $group['group'];
+                        }
+                        \MapasCulturais\i::_e(" em"); 
+                        ?> 
+                        <a href="<?php echo $group['url']; ?>" style="display: initial; color: #4963ad;">
                             <?php echo $group['entitie']; ?>
                         </a>
                     </li>


### PR DESCRIPTION
**Contexto**
Dentro da aba espaço estava vindo um valor group-admin quando um agente era relacionado a administração de qualquer entidade. Então foi trocado o texto da visualização para o valor ADMINISTRADOR(A).

**Issue**
#107 

