### PR TITLE
#117 - 🔨 Script para trocar categorias e especialidades

### DIFF
--- a/Controllers/ProfessionalCategory.php
+++ b/Controllers/ProfessionalCategory.php
@@ -113,7 +113,6 @@ class ProfessionalCategory extends \MapasCulturais\Controller{
             }
            $this->json(['message' => 'Categoria e Especialidade registrada', 'type' => 'success'], 200);
         }
-        die;
     }
 
     function POST_categoriaEspecialidade() {
@@ -192,7 +191,6 @@ class ProfessionalCategory extends \MapasCulturais\Controller{
         WHERE c.owner = {$idCat} AND c.key = 'especialidade'";
         $query  = $app->em->createQuery($dql);
         $catEsp = $query->getResult();
-
         if(!empty($catEsp)) {
             $app->disableAccessControl();
             foreach ($catEsp as $resultValue) {
@@ -235,4 +233,6 @@ class ProfessionalCategory extends \MapasCulturais\Controller{
         $app->em->flush();
         $this->json(['message' => 'Especialidade alterada com sucesso', 'type' => 'success', 'title' => 'Sucesso'], 200);
     }
+
+    
 }

--- a/conf-base.php
+++ b/conf-base.php
@@ -24,7 +24,7 @@ return [
         ]
     ],
 
-    'auth.provider' => 'Fake',
+    'auth.provider' => 'OpauthKeyCloak',
     'auth.config' => [
         'logout_url'            => env('LOGOUT_URL', ''),
         'client_id'             => env('CLIENT_ID', ''),

--- a/layouts/parts/singles/agent-form.php
+++ b/layouts/parts/singles/agent-form.php
@@ -2,10 +2,15 @@
 use \Saude\Entities\ProfessionalCategory;
 
 $allPro = ProfessionalCategory::allProfessional();
-//RETORNA AS CATEGORIAS DO AGENTE
-$getCat = ProfessionalCategory::getCategoryEntity($entity->id, 'profissionais_categorias_profissionais');
+
 //RETORNA AS ESPECIALIDADES DO AGENTE
 $getSpecialty = ProfessionalCategory::getSpecialtyEntity($entity,'profissionais_especialidades');
+
+$upCategoryAndSpecialty = ProfessionalCategory::alterCategoryProfessional($entity->id);
+
+//RETORNA AS CATEGORIAS DO AGENTE
+$getCat = ProfessionalCategory::getCategoryEntity($entity->id, 'profissionais_categorias_profissionais');
+
 ?>
 <div class="ficha-spcultura">
     <?php if($this->isEditable() && $entity->shortDescription && strlen($entity->shortDescription) > 2000): ?>


### PR DESCRIPTION
##**Contexto**
Foi atualizado as categorias e suas especialidades para haver um relacionamento, mas no banco de dados estava como string, então, esse script atualizado os dados do agente no momento que a página do perfil do mesmo for visitada.