### PR TITLE
Fix/corrige ordenacao inscricao

### DIFF
--- a/layouts/parts/singles/opportunity-about--registration-dates.php
+++ b/layouts/parts/singles/opportunity-about--registration-dates.php
@@ -6,11 +6,11 @@ $editable = $this->isEditable() && !isset($disable_editable);
     <div class="registration-dates clear opportunity-phases">
         <?php /* Translators: "de" como início de um intervalo de data *DE* 25/1 a 25/2 às 13:00 */ ?>
         <ul class="list-group">
-            <li class="list-group-item" style="width: 100%;">
+            <li style="width: 100%;">
                 <?php if ($app->auth->isUserAuthenticated()): ?>
                 <button class="btn-access" style="float: left; margin-right: 12px;" title="Acessar inscrições">
                     <i class="fa fa-arrow-circle-right" aria-hidden="true"></i>
-                    <a href="<?= $entity->singleUrl; ?>"> Acessar </a>
+                    <a style="color: white;" href="<?= $entity->singleUrl; ?> "> Acessar </a>
                 </button>
             <?php endif; ?>
                 <?php \MapasCulturais\i::_e("Inscrições abertas de");?>

--- a/views/panel/registrations.php
+++ b/views/panel/registrations.php
@@ -6,14 +6,15 @@ error_reporting(E_ALL);
     
     $drafts = $app->repo('Registration')->findByUser($app->user, Registration::STATUS_DRAFT);
     $sent = $app->repo('Registration')->findByUser($app->user, 'sent');
-
+    
     // ORDENANDO O ARRAY POR DATA DE ENVIO DA INSCRIÇÃO EM ORDEM DECRESCENTE
-    $ord = array();
-    foreach ($sent as $key => $value){
-    $dateTime[] = $value->sentTimestamp->format('d-m-Y H:i:s');
-    }
-    array_multisort($dateTime,SORT_DESC,SORT_STRING,$sent);   
-    ?>
+    if($sent):
+        foreach ($sent as $key => $value){
+        $dateTime[] = $value->sentTimestamp->format('d-m-Y H:i:s');
+        }
+        array_multisort($dateTime,SORT_DESC,SORT_STRING,$sent);   
+    endif;
+ ?>
 
 <div class="panel-list panel-main-content">
     <?php $this->applyTemplateHook('panel-header','before'); ?>


### PR DESCRIPTION
Autor
@FernandaNascimento26 

Contexto
Ordenar todas as inscrições enviados em ordem para ficar da mais recente para a mais antigas.

Teste
Verificar se quando o agente não possui nenhuma inscrição, ele apresente a tela de inscricao e uma mensagem de alerta que informa que o agente não enviou nenhuma inscricao