### PR TITLE
#361 🚧 Removendo obrigatoriedade do campo de atuação

### DIFF
--- a/taxonomies.php
+++ b/taxonomies.php
@@ -17,7 +17,7 @@ return array(
     2 => array(
         //'slug' => i::__('area'),
         'slug' => 'area',
-        'required' => i::__("Você deve informar ao menos uma área de atuação"),
+        //'required' => i::__("Você deve informar ao menos uma área de atuação"),
         'entities' => array(
             'MapasCulturais\Entities\Space',
             'MapasCulturais\Entities\Agent'


### PR DESCRIPTION
Responsáveis:  
@FernandaNascimento26  @ericsonmoreira 

Linked Issue:  
Close #361

### Descrição

Retirada a obrigatoriedade de preenchimento dos campos **Descrição** e **Área de Atuação** na página de cadastro do agente.

### Passos a passo para teste

1. Clicar na foto do Usuário que fica no menu superior.
2. Selecionar a opção **Meu Perfil**.
3. Clicar no botão **Editar** (parte superior direita).
4. Verificar se não existe mais o asterisco indicando obrigatoriedade dos campos **Descrição** e **Área de Atuação**.
4. Remover os valores preenchidos nos campos **Descrição** e **Área de Atuação**.
5. Clicar no botão **Salvar** (parte superior direita).
6. Verificar se as alterações foram salvas com sucesso.

## Checklist para criação do PR

- [ ] Testes foram implementados (novos ou não)
- [x] Issue foi definida no PR (Linked Issue na coluna à direita da página)
- [x] Pessoas contribuidoras foram definidas no PR (Assigners no PR)
