### PR TITLE
Removendo a classe required do Campo de atuação

### DIFF
--- a/layouts/parts/widget-areas.php
+++ b/layouts/parts/widget-areas.php
@@ -1,0 +1,19 @@
+<?php
+$entityClass = $entity->getClassName();
+$entityName = strtolower(array_slice(explode('\\', $entityClass),-1)[0]);
+$areas = array_values($app->getRegisteredTaxonomy($entityClass, 'area')->restrictedTerms);
+sort($areas);
+?>
+<div class="widget">
+    <h3><?php $this->dict('taxonomies:area: name') ?></h3>
+    <?php if($this->isEditable()): ?>
+        <span id="term-area" class="js-editable-taxonomy" data-original-title="<?php $this->dict('taxonomies:area: name') ?>" data-emptytext="<?php $this->dict('taxonomies:area: select at least one') ?>" data-restrict="true" data-taxonomy="area"><?php echo implode('; ', $entity->terms['area'])?></span>
+    <?php else: ?>
+        <?php
+        foreach($areas as $i => $t): if(in_array($t, $entity->terms['area'])): ?>
+            <a class="tag tag-<?php echo $this->controller->id ?>" href="<?php echo $app->createUrl('site', 'search') ?>##(<?php echo $entityName ?>:(areas:!(<?php echo $i ?>)),global:(enabled:(<?php echo $entityName ?>:!t),filterEntity:<?php echo $entityName ?>))">
+                <?php echo $t ?>
+            </a>
+        <?php endif; endforeach; ?>
+    <?php endif;?>
+</div>


### PR DESCRIPTION
Responsáveis:  
@FernandaNascimento26  @ericsonmoreira 

Linked Issue:  
#152 

### Descrição

Retirada a obrigatoriedade de preenchimento dos campos **Descrição** e **Área de Atuação** na página de cadastro do agente.

### Passos a passo para teste

1. Clicar na foto do Usuário que fica no menu superior.
2. Selecionar a opção **Meu Perfil**.
3. Clicar no botão **Editar** (parte superior direita).
4. Verificar se não existe mais o asterisco indicando obrigatoriedade do campo **Área de Atuação**.
4. Remover os valores preenchidos no campo  **Área de Atuação**.
5. Clicar no botão **Salvar** (parte superior direita).
6. Verificar se as alterações foram salvas com sucesso.

## Checklist para criação do PR

- [ ] Testes foram implementados (novos ou não)
- [x] Issue foi definida no PR (Linked Issue na coluna à direita da página)
- [x] Pessoas contribuidoras foram definidas no PR (Assigners no PR)
