### PR TITLE
 Link de atalho para a oportunidade no próprio card de inscrição

### DIFF
--- a/layouts/parts/search/list-edital-item.php
+++ b/layouts/parts/search/list-edital-item.php
@@ -1,24 +1,40 @@
-<article class="objeto clearfix"  ng-repeat="opportunity in opportunities" id="agent-result-{{opportunity.id}}" ng-if="'Edital' == opportunity.type.name || 'Concurso' == opportunity.type.name ">         
+<article class="objeto clearfix" ng-repeat="opportunity in opportunities" id="agent-result-{{opportunity.id}}"
+    ng-if="'Edital' == opportunity.type.name || 'Concurso' == opportunity.type.name ">
     <h1><a href="{{opportunity.singleUrl}}" rel='noopener noreferrer'>{{opportunity.name}}</a></h1>
     <div class="objeto-content clearfix">
         <a href="{{opportunity.singleUrl}}" class="js-single-url" rel='noopener noreferrer'>
-            <img class="objeto-thumb" ng-src="{{opportunity['@files:avatar.avatarMedium'].url||assetsUrl.avatarOpportunity}}">
+            <img class="objeto-thumb"
+                ng-src="{{opportunity['@files:avatar.avatarMedium'].url||assetsUrl.avatarOpportunity}}">
         </a>
         <p class="objeto-resumo">
             {{opportunity.shortDescription}}
         </p>
         <div class="objeto-meta">
             <?php $this->applyTemplateHook('list.opportunity.meta','begin'); ?>
-            <div><span class="label"><?php \MapasCulturais\i::_e("Tipo");?>:</span> <a href="#" rel='noopener noreferrer'>{{opportunity.type.name}}</a></div>
-            <div ng-if="readableOpportunityRegistrationDates(opportunity)"><span class="label"><?php \MapasCulturais\i::_e("Inscrições");?>:</span> {{readableOpportunityRegistrationDates(opportunity)}}</div>
+            <div><span class="label"><?php \MapasCulturais\i::_e("Tipo");?>:</span> <a href="#"
+                    rel='noopener noreferrer'>{{opportunity.type.name}}</a></div>
+            <div ng-if="readableOpportunityRegistrationDates(opportunity)"><span
+                    class="label"><?php \MapasCulturais\i::_e("Inscrições");?>:</span>
+                {{readableOpportunityRegistrationDates(opportunity)}}</div>
             <div>
                 <span class="label">Tags:</span>
                 <span ng-repeat="tags in opportunity.terms.tag">
-                    <a class="tag tag-opportunity" href="<?php echo $app->createUrl('site', 'search') ?>##(opportunity:(keyword:'{{tags}}'),global:(enabled:(opportunity:!t),filterEntity:opportunity,viewMode:list))">{{tags}}</a>
+                    <a class="tag tag-opportunity"
+                        href="<?php echo $app->createUrl('site', 'search') ?>##(opportunity:(keyword:'{{tags}}'),global:(enabled:(opportunity:!t),filterEntity:opportunity,viewMode:list))">{{tags}}</a>
                 </span>
             </div>
             <?php $this->applyTemplateHook('list.opportunity.meta','end'); ?>
         </div>
     </div>
+
+    <br>
+    <div>
+        <button class="btn-access" style="float: left; margin-right: 12px; background-color: #e7e7e7; color: black;;" title="Acessar inscrição">
+            <i class="fa fa-arrow-circle-right" aria-hidden="true"></i>
+            <a style="color: black;" href="{{opportunity.singleUrl}}"> Acessar Inscrição</a>
+        </button>
+    </div>
+    </div>
+
 </article>
 <!--.objeto-->

--- a/layouts/parts/search/list-opportunity-item.php
+++ b/layouts/parts/search/list-opportunity-item.php
@@ -20,5 +20,14 @@
             <?php $this->applyTemplateHook('list.opportunity.meta','end'); ?>
         </div>
     </div>
+
+    <br>
+    <div>
+        <button class="btn-access" style="float: left; margin-right: 12px;" title="Acessar inscrição">
+            <i class="fa fa-arrow-circle-right" aria-hidden="true"></i>
+            <a style="color: white;" href="{{opportunity.singleUrl}}"> Acessar Inscrição</a>
+        </button>
+    </div>
+    </div>
 </article>
 <!--.objeto-->

--- a/layouts/parts/singles/opportunity-about--highlighted-message.php
+++ b/layouts/parts/singles/opportunity-about--highlighted-message.php
@@ -1,0 +1,9 @@
+<div class="highlighted-message clearfix" id="opportunity-main-info">
+    <?php $this->applyTemplateHook('tab-about--highlighted-message','begin'); ?>
+
+    <?php if($this->isEditable() || $entity->registrationFrom || $entity->registrationTo): ?>
+        <?php $this->part('singles/opportunity-about--registration-dates-link', ['entity' => $entity]) ?>
+    <?php endif; ?>
+
+    <?php $this->applyTemplateHook('tab-about--highlighted-message','end'); ?>
+</div>

--- a/layouts/parts/singles/opportunity-about--registration-dates-link.php
+++ b/layouts/parts/singles/opportunity-about--registration-dates-link.php
@@ -1,0 +1,39 @@
+<?php
+$editable = $this->isEditable() && !isset($disable_editable);
+
+?>
+<?php if($editable || $entity->registrationFrom): ?>
+<div class="registration-dates clear opportunity-phases">
+    <?php /* Translators: "de" como início de um intervalo de data *DE* 25/1 a 25/2 às 13:00 */ ?>
+    <ul class="list-group">
+        <li style="width: 100%;">
+        <?php if ($app->auth->isUserAuthenticated()): ?>
+                <button class="btn-access" style="float: left; margin-right: 12px;" title="Acessar inscrições">
+                    <i class="fa fa-arrow-circle-right" aria-hidden="true"></i>
+                    <a style="color: white;" href="<?= $entity->singleUrl; ?> "> Acessar </a>
+                </button>
+            <?php endif; ?>
+            <?php \MapasCulturais\i::_e("Inscrições abertas de");?>
+            <strong <?php if($editable): ?> class="js-editable" <?php endif; ?> data-type="date"
+                data-yearrange="2000:+25" data-viewformat="dd/mm/yyyy" data-edit="registrationFrom"
+                <?php echo $entity->registrationFrom ? "data-value='" . $entity->registrationFrom->format('Y-m-d') . "'" : ' '?>
+                data-showbuttons="false"
+                data-emptytext="<?php \MapasCulturais\i::esc_attr_e("Data inicial");?>"><?php echo $entity->registrationFrom ? $entity->registrationFrom->format('d/m/Y') : \MapasCulturais\i::__("Data inicial"); ?></strong>
+            <?php /* Translators: "a" indicando intervalo de data de 25/1 *A* 25/2 às 13:00 */ ?>
+            <?php \MapasCulturais\i::_e("a");?>
+            <strong <?php if($editable): ?> class="js-editable" <?php endif; ?> data-type="date"
+                data-yearrange="2000:+25" data-viewformat="dd/mm/yyyy" data-edit="registrationTo"
+                <?php echo $entity->registrationTo ? "data-value='".$entity->registrationTo->format('Y-m-d') . "'" : ''?>
+                data-timepicker="#registrationTo_time" data-showbuttons="false"
+                data-emptytext="<?php \MapasCulturais\i::esc_attr_e("Data final");?>"><?php echo $entity->registrationTo ? $entity->registrationTo->format('d/m/Y') : \MapasCulturais\i::__("Data final"); ?></strong>
+            <?php /* Translators: "às" indicando horário de data de 25/1 a 25/2 *ÀS* 13:00 */ ?>
+            <?php \MapasCulturais\i::_e("às");?>
+            <strong <?php if($editable): ?> class="js-editable" id="registrationTo_time" <?php endif; ?>
+                data-datetime-value="<?php echo $entity->registrationTo ? $entity->registrationTo->format('Y-m-d H:i') : ''; ?>"
+                data-placeholder="<?php \MapasCulturais\i::esc_attr_e("Hora final");?>"
+                data-emptytext="<?php \MapasCulturais\i::esc_attr_e("Hora final");?>"><?php echo $entity->registrationTo ? $entity->registrationTo->format('H:i') : ''; ?></strong>
+            .
+        </li>
+    </ul>
+</div>
+<?php endif; ?>

--- a/layouts/parts/singles/opportunity-about--registration-dates.php
+++ b/layouts/parts/singles/opportunity-about--registration-dates.php
@@ -7,12 +7,6 @@ $editable = $this->isEditable() && !isset($disable_editable);
         <?php /* Translators: "de" como início de um intervalo de data *DE* 25/1 a 25/2 às 13:00 */ ?>
         <ul class="list-group">
             <li style="width: 100%;">
-                <?php if ($app->auth->isUserAuthenticated()): ?>
-                <button class="btn-access" style="float: left; margin-right: 12px;" title="Acessar inscrições">
-                    <i class="fa fa-arrow-circle-right" aria-hidden="true"></i>
-                    <a style="color: white;" href="<?= $entity->singleUrl; ?> "> Acessar </a>
-                </button>
-            <?php endif; ?>
                 <?php \MapasCulturais\i::_e("Inscrições abertas de");?>
         <strong <?php if($editable): ?> class="js-editable" <?php endif; ?> data-type="date" data-yearrange="2000:+25" data-viewformat="dd/mm/yyyy" data-edit="registrationFrom" <?php echo $entity->registrationFrom ? "data-value='" . $entity->registrationFrom->format('Y-m-d') . "'" : ' '?> data-showbuttons="false" data-emptytext="<?php \MapasCulturais\i::esc_attr_e("Data inicial");?>"><?php echo $entity->registrationFrom ? $entity->registrationFrom->format('d/m/Y') : \MapasCulturais\i::__("Data inicial"); ?></strong>
         <?php /* Translators: "a" indicando intervalo de data de 25/1 *A* 25/2 às 13:00 */ ?>


### PR DESCRIPTION
Responsáveis:  
@FernandaNascimento26  

Linked Issue: Close  #156

### Descrição

Foi inserido botão de atalho, com nome Acessar Inscrição , na listagem de oportunidades, em todas abas em que seja listada uma oportunidade (Editais, Oportunidades e Subprojetos), para que assim o usuário possa verificar os detalhes de uma oportunidade.

### Passos a passo para teste

1. Acessar o menu de projetos
2. clicar no botão **Acessar Inscrição** para acessar a página principal da oportunidade

---
1. Acessar o menu de oportunidades
2. clicar no botão **Acessar Inscrição** para acessar a página principal da oportunidade

--

1. Acessar o menu de Editais
2. clicar no botão **Acessar Inscrição** para acessar a página principal da oportunidade


## Checklist para criação do PR

- [ ] Testes foram implementados (novos ou não)
- [x] Issue foi definida no PR (Linked Issue na coluna à direita da página)
- [x] Pessoas contribuidoras foram definidas no PR (Assigners no PR)
