### PR TITLE
Retornar para a página de inscrição, após usuário ter realizado cadastro no ID Saúde

### DIFF
--- a/assets/js/editable.js
+++ b/assets/js/editable.js
@@ -793,26 +793,32 @@ MapasCulturais.Editables = {
                         removeClass('danger');
 
 
-                        //parametro passado pelo backend para controllar o redirecionamento apos salvar a entidade
-                        // exemplo no backend: 
-                        // $json->redirect = "true";
-                        // $json->url = ['controller'=>'aldirblanc', 'action'=>'selecionaragente'];
-                        if (response.redirect == undefined || response.redirect === 'true') {
-                            if (response.url) {
+                        if (response.newRedirect === 'true') {
+                            if (response.newRedirectUrl) {
+                                document.location = response.newRedirectUrl;
+                            }
+                        } else {
+                            //parametro passado pelo backend para controllar o redirecionamento apos salvar a entidade
+                            // exemplo no backend:
+                            // $json->redirect = "true";
+                            // $json->url = ['controller'=>'aldirblanc', 'action'=>'selecionaragente'];
+                            if (response.redirect == undefined || response.redirect === 'true') {
+                                if (response.url) {
 
-                                document.location = MapasCulturais.createUrl(response.url.controller, response.url.action, [response.id]);
+                                    document.location = MapasCulturais.createUrl(response.url.controller, response.url.action, [response.id]);
 
-                            } else {
+                                } else {
 
-                                if (MapasCulturais.request.controller != 'registration' && (action === 'create' || response.status != MapasCulturais.entity.status)) {
-                                    if (response.status == 1) {
-                                        document.location = MapasCulturais.createUrl(controller, 'single', [response.id]);
-                                    } else {
-                                        document.location = MapasCulturais.createUrl(controller, 'edit', [response.id]);
+                                    if (MapasCulturais.request.controller != 'registration' && (action === 'create' || response.status != MapasCulturais.entity.status)) {
+                                        if (response.status == 1) {
+                                            document.location = MapasCulturais.createUrl(controller, 'single', [response.id]);
+                                        } else {
+                                            document.location = MapasCulturais.createUrl(controller, 'edit', [response.id]);
+                                        }
                                     }
                                 }
-                            }
 
+                            }
                         }
 
 


### PR DESCRIPTION
Responsáveis:  
@ericsonmoreira  @victorMagalhaesPacheco 

Linked Issue: Close #362

### Descrição

Deverá ser realizado redirecionamento de páginas, para que quando um usuário sem cadastro esteja acessando uma oportunidade e queira realizar sua inscrição, quando o sistema o redirecionar para página do ID Saúde para criar o cadastro, então após o usuário concluir o cadastro no ID saúde, o acesso deverá voltar para a página que o usuário estava inicialmente, da oportunidade em questão.

### Passos a passo para teste

#### Caso de usuário **com cadastro**

1. Acessar uma página qualquer estando não logado no sistema
2. Lembre-se do caminho para essa página
3. Se autenticar pelo serviço do **idSaúde**
4. Verificar se, após a autenticação, o usuário é redirecionado para a página do passo **2**.

#### Caso de usuário já **sem cadastro**

1. Acessar uma página qualquer estando não logado no sistema
2. Lembre-se do caminho para essa página
3. Se autenticar pelo serviço do **idSaúde**
4. Publicar o cadastro no botão **Publicar** na parte superior direita
5. Verificar se, após a autenticação, o usuário é redirecionado para a página do passo **2**.

## _Checklist_ para criação do PR

- [ ] Testes foram implementados (novos ou não)
- [x] Issue foi definida no PR (Linked Issue na coluna à direita da página)
- [x] Pessoas contribuidoras foram definidas no PR (Assigners no PR)
