### PR TITLE
Feature/status description 441

### DIFF
--- a/layouts/parts/singles/opportunity-registrations--tables--manager.php
+++ b/layouts/parts/singles/opportunity-registrations--tables--manager.php
@@ -1,34 +1,35 @@
 <?php
+
 use MapasCulturais\i;
 
 ?>
 <header id="header-inscritos" class="clearfix">
-    <?php $this->applyTemplateHook('header-inscritos','begin'); ?>
-    <h3><?php i::_e("Inscritos");?></h3>
+    <?php $this->applyTemplateHook('header-inscritos', 'begin'); ?>
+    <h3><?php i::_e("Inscritos"); ?></h3>
     <div class="alert info hide-tablet">
-        <?php i::_e("Não é possível alterar o status das inscrições através desse dispositivo. Tente a partir de um dispositivo com tela maior.");?>
+        <?php i::_e("Não é possível alterar o status das inscrições através desse dispositivo. Tente a partir de um dispositivo com tela maior."); ?>
         <div class="close"></div>
     </div>
-    <?php $this->applyTemplateHook('header-inscritos','actions'); ?>
-    <a class="btn btn-default download" href="<?php echo $this->controller->createUrl('report', [$entity->id]); ?>"><?php i::_e("Baixar inscritos");?></a>
-    <a class="btn btn-default download" href="<?php echo $this->controller->createUrl('reportDrafts', [$entity->id]); ?>"><?php i::_e("Baixar rascunhos");?></a>
-    <?php $this->applyTemplateHook('header-inscritos','end'); ?>
+    <?php $this->applyTemplateHook('header-inscritos', 'actions'); ?>
+    <a class="btn btn-default download" href="<?php echo $this->controller->createUrl('report', [$entity->id]); ?>"><?php i::_e("Baixar inscritos"); ?></a>
+    <a class="btn btn-default download" href="<?php echo $this->controller->createUrl('reportDrafts', [$entity->id]); ?>"><?php i::_e("Baixar rascunhos"); ?></a>
+    <?php $this->applyTemplateHook('header-inscritos', 'end'); ?>
 </header>
 <div id='status-info' class="alert info">
-    <p><?php i::_e("Altere os status das inscrições na última coluna da tabela de acordo com o seguinte critério:");?></p>
+    <p><?php i::_e("Altere os status das inscrições na última coluna da tabela de acordo com o seguinte critério:"); ?></p>
     <ul>
-        <li><span><?php i::_e("Inválida - em desacordo com o regulamento (ex. documentação incorreta).");?></span></li>
-        <li><span><?php i::_e("Pendente - ainda não avaliada.");?></span></li>
-        <li><span><?php i::_e("Não selecionada - avaliada, mas não selecionada.");?></span></li>
-        <li><span><?php i::_e("Suplente - avaliada, mas aguardando vaga.");?></span></li>
-        <li><span><?php i::_e("Selecionada - avaliada e selecionada.");?></span></li>
-        <li><span><?php i::_e("Rascunho - utilize essa opção para permitir que o responsável edite e reenvie uma inscrição. Ao selecionar esta opção, a inscrição não será mais exibida nesta tabela.");?></span></li>
+        <li><span><?php i::_e("Inválida - em desacordo com o regulamento (ex. documentação incorreta)."); ?></span></li>
+        <li><span><?php i::_e("Pendente - ainda não avaliada."); ?></span></li>
+        <li><span><?php i::_e("Não selecionada - avaliada, mas não selecionada."); ?></span></li>
+        <li><span><?php i::_e("Suplente - avaliada, mas aguardando vaga."); ?></span></li>
+        <li><span><?php i::_e("Selecionada - avaliada e selecionada."); ?></span></li>
+        <li><span><?php i::_e("Rascunho - utilize essa opção para permitir que o responsável edite e reenvie uma inscrição. Ao selecionar esta opção, a inscrição não será mais exibida nesta tabela."); ?></span></li>
     </ul>
     <div class="close"></div>
 </div>
 
 <div id="filtro-inscritos">
-    <span class="label"> <?php i::_e("Filtrar inscrição:");?> </span>
+    <span class="label"> <?php i::_e("Filtrar inscrição:"); ?> </span>
     <input ng-model="data.registrationsFilter" placeholder="<?php i::_e('Busque pelo número de inscrição, status da avaliação, nome ou cpf do responsável') ?>" />
 </div>
 
@@ -39,14 +40,10 @@ use MapasCulturais\i;
             <input type="text" ng-model="filter_dropdown" style="width:100%;" placeholder="Busque pelo nome dos campos do formulário de inscrição e selecione as colunas visíveis" />
         </div>
         <ul class="filter-list">
-            <li ng-repeat="field in data.defaultSelectFields | filter:filter_dropdown" ng-if="field.required"
-                ng-class="{'selected':isSelected(data.registrationTableColumns, field.fieldName)}"
-                ng-click="toggleSelectionColumn(data.registrationTableColumns, field.fieldName)" >
+            <li ng-repeat="field in data.defaultSelectFields | filter:filter_dropdown" ng-if="field.required" ng-class="{'selected':isSelected(data.registrationTableColumns, field.fieldName)}" ng-click="toggleSelectionColumn(data.registrationTableColumns, field.fieldName)">
                 <span>{{field.title}}</span>
             </li>
-            <li ng-repeat="field in data.opportunitySelectFields | filter:filter_dropdown" ng-if="field.required"
-                ng-class="{'selected':isSelected(data.registrationTableColumns, field.fieldName)}"
-                ng-click="toggleSelectionColumn(data.registrationTableColumns, field.fieldName)" >
+            <li ng-repeat="field in data.opportunitySelectFields | filter:filter_dropdown" ng-if="field.required" ng-class="{'selected':isSelected(data.registrationTableColumns, field.fieldName)}" ng-click="toggleSelectionColumn(data.registrationTableColumns, field.fieldName)">
                 <span>{{field.title}}</span>
             </li>
         </ul>
@@ -55,10 +52,10 @@ use MapasCulturais\i;
 
 
 <div id="selected-filters" style="width:100%; margin:10px 0px;">
-     <span>
-        <a ng-repeat="field in data.defaultSelectFields" ng-click="toggleSelectionColumn(data.registrationTableColumns, field.fieldName)"  class="tag-selected tag-opportunity" ng-if="isSelected(data.registrationTableColumns, field.fieldName)"  rel='noopener noreferrer'>{{field.title}}</a>
-        <a ng-repeat="field in data.opportunitySelectFields" ng-click="toggleSelectionColumn(data.registrationTableColumns, field.fieldName)"  class="tag-selected tag-opportunity" ng-if="isSelected(data.registrationTableColumns, field.fieldName)"  rel='noopener noreferrer'>{{field.title}}</a>
-     </span>
+    <span>
+        <a ng-repeat="field in data.defaultSelectFields" ng-click="toggleSelectionColumn(data.registrationTableColumns, field.fieldName)" class="tag-selected tag-opportunity" ng-if="isSelected(data.registrationTableColumns, field.fieldName)" rel='noopener noreferrer'>{{field.title}}</a>
+        <a ng-repeat="field in data.opportunitySelectFields" ng-click="toggleSelectionColumn(data.registrationTableColumns, field.fieldName)" class="tag-selected tag-opportunity" ng-if="isSelected(data.registrationTableColumns, field.fieldName)" rel='noopener noreferrer'>{{field.title}}</a>
+    </span>
 </div>
 
 
@@ -68,118 +65,123 @@ use MapasCulturais\i;
     }
 </style>
 <div id="registrations-table-container">
-<div style="float: right;" class="selected-opportunity">
-    Mudar status para selecionada (Pendente)
-    <input type="checkbox" name="checkselected" id="checkselected" ng-click="setStatusToSelected()" style="margin-left: 10px; margin-right: 10px;" > 
-</div>
-<table id="registrations-table" class="js-registration-list registrations-table" ng-class="{'no-options': data.entity.registrationCategories.length === 0, 'no-attachments': data.entity.registrationFileConfigurations.length === 0, 'registrations-results': data.entity.published, 'fullscreen': data.fullscreenTable}"><!-- adicionar a classe registrations-results quando resultados publicados-->
-    <thead>
+    <div style="float: right;" class="selected-opportunity">
+        Mudar status para selecionada (Pendente)
+        <input type="checkbox" name="checkselected" id="checkselected" ng-click="setStatusToSelected()" style="margin-left: 10px; margin-right: 10px;">
+    </div>
+    <table id="registrations-table" class="js-registration-list registrations-table" ng-class="{'no-options': data.entity.registrationCategories.length === 0, 'no-attachments': data.entity.registrationFileConfigurations.length === 0, 'registrations-results': data.entity.published, 'fullscreen': data.fullscreenTable}">
+        <!-- adicionar a classe registrations-results quando resultados publicados-->
+        <thead>
+            <tr>
+                <?php $this->applyTemplateHook('registration-list-header', 'begin'); ?>
+                <th ng-show="data.registrationTableColumns.number" class="registration-id-col">
+                    <?php i::_e("Inscrição"); ?>
+                </th>
+                <th ng-show="data.registrationTableColumns.category" ng-if="data.entity.registrationCategories" class="registration-option-col" title="{{data.registrationCategory}}">
+                    <mc-select class="left transparent-placeholder" placeholder="status" model="registrationsFilters['category']" data="data.registrationCategoriesToFilter" title="{{data.registrationCategory}}"></mc-select>
+                </th>
+                <th ng-repeat="field in data.opportunitySelectFields" ng-show="data.registrationTableColumns[field.fieldName]" class="registration-option-col">
+                    <mc-select class="left transparent-placeholder" placeholder="{{field.title}}" model="registrationsFilters[field.fieldName]" data="field.options" title="{{field.title}}"></mc-select>
+                </th>
+                <th ng-show="data.registrationTableColumns.agents" class="registration-agents-col">
+                    <?php i::_e("Agentes"); ?>
+                </th>
+                <th ng-show="data.registrationTableColumns.attachments" ng-if="data.entity.registrationFileConfigurations.length > 0" class="registration-attachments-col">
+                    <?php i::_e("Anexos"); ?>
+                </th>
+                <th ng-show="data.registrationTableColumns.evaluation" class="registration-status-col">
+                    <?php i::_e("Avaliação"); ?>
+                </th>
+                <th ng-show="data.registrationTableColumns.status" class="registration-status-col">
+                    <mc-select placeholder="Status" model="registrationsFilters['status']" data="data.registrationStatuses"></mc-select>
+                </th>
+
+                <?php $this->applyTemplateHook('registration-list-header', 'end'); ?>
+            </tr>
+        </thead>
         <tr>
-            <?php $this->applyTemplateHook('registration-list-header','begin'); ?>
-            <th ng-show="data.registrationTableColumns.number" class="registration-id-col">
-                <?php i::_e("Inscrição");?>
-            </th>            
-            <th ng-show="data.registrationTableColumns.category" ng-if="data.entity.registrationCategories" class="registration-option-col" title="{{data.registrationCategory}}">
-                <mc-select class="left transparent-placeholder" placeholder="status" model="registrationsFilters['category']" data="data.registrationCategoriesToFilter" title="{{data.registrationCategory}}"></mc-select>
-            </th>
-            <th ng-repeat="field in data.opportunitySelectFields" ng-show="data.registrationTableColumns[field.fieldName]" class="registration-option-col">
-                <mc-select class="left transparent-placeholder" placeholder="{{field.title}}" model="registrationsFilters[field.fieldName]" data="field.options" title="{{field.title}}"></mc-select>
-            </th>
-            <th ng-show="data.registrationTableColumns.agents" class="registration-agents-col">
-                <?php i::_e("Agentes");?>
-            </th>
-            <th ng-show="data.registrationTableColumns.attachments" ng-if="data.entity.registrationFileConfigurations.length > 0" class="registration-attachments-col">
-                <?php i::_e("Anexos");?>
-            </th>
-            <th ng-show="data.registrationTableColumns.evaluation" class="registration-status-col">
-                <?php i::_e("Avaliação");?>
-            </th>
-            <th ng-show="data.registrationTableColumns.status" class="registration-status-col">
-                <mc-select placeholder="Status" model="registrationsFilters['status']" data="data.registrationStatuses"></mc-select>
-            </th>
+            <td colspan='{{numberOfEnabledColumns()}}'>
+                <label class="alignright"><input type="checkbox" class="hltip" ng-model="data.fullscreenTable"> <?php i::_e('Expandir tabela') ?></label>
 
-            <?php $this->applyTemplateHook('registration-list-header','end'); ?>
-        </tr>
-    </thead>
-    <tr>
-        <td colspan='{{numberOfEnabledColumns()}}'>
-            <label class="alignright"><input type="checkbox" class="hltip" ng-model="data.fullscreenTable"> <?php i::_e('Expandir tabela')?></label>
-            
-            <span ng-if="!usingRegistrationsFilters() && data.registrationsAPIMetadata.count === 0"><?php i::_e("Nenhuma inscrição.");?></span>
-            <span ng-if="usingRegistrationsFilters() && data.registrationsAPIMetadata.count === 0"><?php i::_e("Nenhuma inscrição encontrada com os filtros selecionados.");?></span>
-            <span ng-if="!usingRegistrationsFilters() && data.registrationsAPIMetadata.count === 1"><?php i::_e("1 inscrição.");?></span>
-            <span ng-if="usingRegistrationsFilters() && data.registrationsAPIMetadata.count === 1"><?php i::_e("1 inscrição encontrada com os filtros selecionados.");?></span>
-            <span ng-if="!usingRegistrationsFilters() && data.registrationsAPIMetadata.count > 1">
-                {{data.registrations.length}} <i> de {{ data.registrationsAPIMetadata.count }}</i> <?php i::_e("inscrições.");?>
-                <?php if($entity->registrationLimit > 0):?>
-                    | <?php i::_e("Número máximo de vagas na oportunidade:");?> <?php echo $entity->registrationLimit;?>
-                <?php endif;?>
-            </span>
-            <div ng-if="usingRegistrationsFilters() && data.registrationsAPIMetadata.count > 1">
-                <div ng-if="data.registrations.length === 0">
-                    <?php i::_e("Nenhuma inscrição encontrada com os filtros selecionados."); ?>
-                </div>
-                <div ng-if="data.registrations.length >= 1 ">
-                    <strong> {{ data.registrations.length }} </strong>
-                    <span ng-if="data.registrationsAPIMetadata.count > 1"> de {{ data.registrationsAPIMetadata.count }}</i> </span>
-                    <span ng-if="data.registrations.length === 1"> <?php i::_e("inscrição encontrada"); ?> </span>
-                    <span ng-if="data.registrations.length > 1"> <?php i::_e("inscrições encontradas"); ?> </span>
-                    <?php i::_e(" com os filtros selecionados."); ?>
-                </div>
+                <span ng-if="!usingRegistrationsFilters() && data.registrationsAPIMetadata.count === 0"><?php i::_e("Nenhuma inscrição."); ?></span>
+                <span ng-if="usingRegistrationsFilters() && data.registrationsAPIMetadata.count === 0"><?php i::_e("Nenhuma inscrição encontrada com os filtros selecionados."); ?></span>
+                <span ng-if="!usingRegistrationsFilters() && data.registrationsAPIMetadata.count === 1"><?php i::_e("1 inscrição."); ?></span>
+                <span ng-if="usingRegistrationsFilters() && data.registrationsAPIMetadata.count === 1"><?php i::_e("1 inscrição encontrada com os filtros selecionados."); ?></span>
+                <span ng-if="!usingRegistrationsFilters() && data.registrationsAPIMetadata.count > 1">
+                    {{data.registrations.length}} <i> de {{ data.registrationsAPIMetadata.count }}</i> <?php i::_e("inscrições."); ?>
+                    <?php if ($entity->registrationLimit > 0) : ?>
+                        | <?php i::_e("Número máximo de vagas na oportunidade:"); ?> <?php echo $entity->registrationLimit; ?>
+                    <?php endif; ?>
+                </span>
+                <div ng-if="usingRegistrationsFilters() && data.registrationsAPIMetadata.count > 1">
+                    <div ng-if="data.registrations.length === 0">
+                        <?php i::_e("Nenhuma inscrição encontrada com os filtros selecionados."); ?>
+                    </div>
+                    <div ng-if="data.registrations.length >= 1 ">
+                        <strong> {{ data.registrations.length }} </strong>
+                        <span ng-if="data.registrationsAPIMetadata.count > 1"> de {{ data.registrationsAPIMetadata.count }}</i> </span>
+                        <span ng-if="data.registrations.length === 1"> <?php i::_e("inscrição encontrada"); ?> </span>
+                        <span ng-if="data.registrations.length > 1"> <?php i::_e("inscrições encontradas"); ?> </span>
+                        <?php i::_e(" com os filtros selecionados."); ?>
+                    </div>
 
-            </div>
-        </td>
-    </tr>
-    <tbody>
-    <tr ng-repeat="reg in data.registrations" id="registration-{{reg.id}}" ng-class="getStatusSlug(reg.status)">
-    <?php $this->applyTemplateHook('registration-list-item','begin'); ?>
-            <td ng-show="data.registrationTableColumns.number" class="registration-id-col"><a href="{{reg.singleUrl}}" rel='noopener noreferrer'>{{reg.number}}</a></td>
-            <td ng-show="data.registrationTableColumns.category" ng-if="data.entity.registrationCategories" class="registration-option-col">{{reg.category}}</td>
-            <td ng-repeat="field in data.opportunitySelectFields" ng-if="data.registrationTableColumns[field.fieldName]" class="registration-option-col">
-                {{reg[field.fieldName]}}
-            </td>
-            <td ng-show="data.registrationTableColumns.agents" class="registration-agents-col">
-                <p>
-                    <span class="label"><?php i::_e("Responsável");?></span><br />
-                    <a href="{{reg.owner.singleUrl}}" rel='noopener noreferrer'>{{reg.owner.name}}</a>
-                </p>
-
-                <p ng-repeat="relation in reg.agentRelations" ng-if="relation.agent">
-                    <span class="label">{{relation.label}}</span><br />
-                    <a href="{{relation.agent.singleUrl}}" rel='noopener noreferrer'>{{relation.agent.name}}</a>
-                </p>
-            </td>
-            <td ng-show="data.registrationTableColumns.attachments" ng-if="data.entity.registrationFileConfigurations.length > 0" class="registration-attachments-col">
-                <a ng-if="reg.files.zipArchive.url" class="icon icon-download" href="{{reg.files.zipArchive.url}}" rel='noopener noreferrer'><div class="screen-reader-text"><?php i::_e("Baixar arquivos");?></div></a>
-            </td>
-            <td ng-show="data.registrationTableColumns.evaluation" class="registration-status-col">
-                {{reg.evaluationResultString}}
-            </td>
-
-            <td ng-show="data.registrationTableColumns.status" class="registration-status-col">
-                <?php if ($entity->publishedRegistrations): ?>
-                    <span class="status status-{{getStatusSlug(reg.status)}}">{{getStatusNameById(reg.status)}}</span>
-                <?php else: ?>
-                    <mc-select model="reg" data="data.registrationStatusesNames" getter="getRegistrationStatus" setter="setRegistrationStatus"></mc-select>
-                <?php endif; ?>
-            </td>
-            <?php $this->applyTemplateHook('registration-list-item','end'); ?>
-        </tr>
-    </tbody>
-    <tfoot>
-        <tr>
-            <td colspan='{{numberOfEnabledColumns()}}' align="center">
-                <div ng-if="data.findingRegistrations">
-                    <img src="<?php $this->asset('img/spinner_192.gif')?>" width="48">
                 </div>
             </td>
         </tr>
-    </tfoot>
-</table>
+        <tbody>
+            <tr ng-repeat="reg in data.registrations" id="registration-{{reg.id}}" ng-class="getStatusSlug(reg.status)">
+                <?php $this->applyTemplateHook('registration-list-item', 'begin'); ?>
+                <td ng-show="data.registrationTableColumns.number" class="registration-id-col"><a href="{{reg.singleUrl}}" rel='noopener noreferrer'>{{reg.number}}</a></td>
+                <td ng-show="data.registrationTableColumns.category" ng-if="data.entity.registrationCategories" class="registration-option-col">{{reg.category}}</td>
+                <td ng-repeat="field in data.opportunitySelectFields" ng-if="data.registrationTableColumns[field.fieldName]" class="registration-option-col">
+                    {{reg[field.fieldName]}}
+                </td>
+                <td ng-show="data.registrationTableColumns.agents" class="registration-agents-col">
+                    <p>
+                        <span class="label"><?php i::_e("Responsável"); ?></span><br />
+                        <a href="{{reg.owner.singleUrl}}" rel='noopener noreferrer'>{{reg.owner.name}}</a>
+                    </p>
+
+                    <p ng-repeat="relation in reg.agentRelations" ng-if="relation.agent">
+                        <span class="label">{{relation.label}}</span><br />
+                        <a href="{{relation.agent.singleUrl}}" rel='noopener noreferrer'>{{relation.agent.name}}</a>
+                    </p>
+                </td>
+                <td ng-show="data.registrationTableColumns.attachments" ng-if="data.entity.registrationFileConfigurations.length > 0" class="registration-attachments-col">
+                    <a ng-if="reg.files.zipArchive.url" class="icon icon-download" href="{{reg.files.zipArchive.url}}" rel='noopener noreferrer'>
+                        <div class="screen-reader-text"><?php i::_e("Baixar arquivos"); ?></div>
+                    </a>
+                </td>
+                <td ng-show="data.registrationTableColumns.evaluation" class="registration-status-col">
+                    {{reg.evaluationResultString}}
+                </td>
+
+                <td ng-show="data.registrationTableColumns.status" class="registration-status-col">
+                    <?php if ($entity->publishedRegistrations) : ?>
+                        <span class="status status-{{getStatusSlug(reg.status)}}">{{getStatusNameById(reg.status)}}</span>
+                    <?php else : ?>
+                        <!-- TODO: testando aqui -->
+                        <mc-select model="reg" data="data.registrationStatusesNames" getter="getRegistrationStatus" setter="setRegistrationStatus"></mc-select>
+                    <?php endif; ?>
+                </td>
+                
+                <?php $this->applyTemplateHook('registration-list-item', 'end'); ?>
+            </tr>
+        </tbody>
+        <tfoot>
+            <tr>
+                <td colspan='{{numberOfEnabledColumns()}}' align="center">
+                    <div ng-if="data.findingRegistrations">
+                        <img src="<?php $this->asset('img/spinner_192.gif') ?>" width="48">
+                    </div>
+                </td>
+            </tr>
+        </tfoot>
+    </table>
 
     <?php
     $_evaluation_type = $entity->evaluationMethodConfiguration->getType();
-    if( is_object($_evaluation_type) && property_exists($_evaluation_type, "id") && $_evaluation_type->id === "simple" ): ?>
+    if (is_object($_evaluation_type) && property_exists($_evaluation_type, "id") && $_evaluation_type->id === "simple") : ?>
         <div ng-if="hasEvaluations()">
             <button class="btn btn-primary" ng-click="applyEvaluations()"> {{ data.confirmEvaluationLabel }} </button>
         </div>

--- a/layouts/parts/singles/opportunity-registrations--user-registrations.php
+++ b/layouts/parts/singles/opportunity-registrations--user-registrations.php
@@ -125,7 +125,7 @@ if (!empty($registrations)) {
                         case 0:
                             $status = 'Rascunho';
                             $colorStatus = 'statusrasc';
-                            $title = 'Utilize essa opção para permitir que o responsável edite e reenvie uma inscrição. Ao selecionar esta opção, a inscrição não será mais exibida nesta tabela.';
+                            $title = 'O candidato poderá editar e reenviar a sua inscrição.';
                             break;
                         case 1:
                             $status = 'Pendente';
@@ -135,7 +135,7 @@ if (!empty($registrations)) {
                         case 2:
                             $status = 'Inválida';
                             $colorStatus = 'statusinv';
-                            $title = 'Em desacordo com o regulamento (ex. documentação incorreta).';
+                            $title = 'Em desacordo com o regulamento.';
                             break;
                         case 3:
                             $status = 'Não selecionada';

--- a/layouts/parts/singles/opportunity-registrations--user-registrations.php
+++ b/layouts/parts/singles/opportunity-registrations--user-registrations.php
@@ -1,6 +1,4 @@
 <?php
-ini_set('display_errors', 1);
-error_reporting(E_ALL);
 
 use Saude\Entities\Resources;
 use \MapasCulturais\Entities\RegistrationEvaluation;

--- a/layouts/parts/singles/opportunity-registrations--user-registrations.php
+++ b/layouts/parts/singles/opportunity-registrations--user-registrations.php
@@ -155,7 +155,7 @@ if (!empty($registrations)) {
                     }
                     ?>
                     <td class="registration-status-col <?php echo $colorStatus; ?>" style="text-align: center; font-size: 11px;">
-                        <p title="<?php echo $title; ?>"><?php echo $status; ?></p>
+                        <?php $this->part('singles/tooltip', ['title' => $title, 'chield' => $status]); ?>
                     </td>
                     <?php $this->applyTemplateHook('user-registration-table--registration', 'end', $reg_args); ?>
                 </tr>

--- a/layouts/parts/singles/opportunity-registrations--user-registrations.php
+++ b/layouts/parts/singles/opportunity-registrations--user-registrations.php
@@ -1,8 +1,10 @@
 <?php
-    ini_set('display_errors', 1);
-    error_reporting(E_ALL);
+ini_set('display_errors', 1);
+error_reporting(E_ALL);
+
 use Saude\Entities\Resources;
 use \MapasCulturais\Entities\RegistrationEvaluation;
+
 $registrations = $app->repo('Registration')->findByOpportunityAndUser($entity, $app->user);
 
 if (!empty($registrations)) {
@@ -18,87 +20,86 @@ if (!empty($registrations)) {
 
 </style>
 <?php if ($registrations) : ?>
-<table class="my-registrations" style="width: 100%">
-    <caption class="caption-table"><?php \MapasCulturais\i::_e("Minhas inscrições"); ?></caption>
-    <thead>
-        <tr>
-            <th class="registration-status-col" style="text-align: center;width: 20%">
-                <?php \MapasCulturais\i::_e("Inscrição"); ?>
-            </th>
-            <th class="registration-agents-col" style="text-align: center;">
-                <?php \MapasCulturais\i::_e("Agentes"); ?>
-            </th>
-            <th class="registration-status-col" style="text-align: left; text-align: center;">
-                <?php \MapasCulturais\i::_e("Data de Envio"); ?>
-            </th>
-            <?php if (
+    <table class="my-registrations" style="width: 100%">
+        <caption class="caption-table"><?php \MapasCulturais\i::_e("Minhas inscrições"); ?></caption>
+        <thead>
+            <tr>
+                <th class="registration-status-col" style="text-align: center;width: 20%">
+                    <?php \MapasCulturais\i::_e("Inscrição"); ?>
+                </th>
+                <th class="registration-agents-col" style="text-align: center;">
+                    <?php \MapasCulturais\i::_e("Agentes"); ?>
+                </th>
+                <th class="registration-status-col" style="text-align: left; text-align: center;">
+                    <?php \MapasCulturais\i::_e("Data de Envio"); ?>
+                </th>
+                <?php if (
                     $verifyPublish->publishedRegistrations == true
                     && $typeEvaluation[0]->type->id == 'technical'
                 ) : ?>
-            <th class="registration-status-col" style="text-align: center;">
-                <?php \MapasCulturais\i::_e("Nota preliminar"); ?>
-            </th>
-            <th class="registration-status-col" style="text-align: center; width: 20%;">
-                <?php \MapasCulturais\i::_e("Nota final"); ?>
-            </th>
-            <?php endif; ?>
-            <th class="registration-status-col" style="text-align: center;width: 20%">
-                <?php \MapasCulturais\i::_e("Status"); ?>
-            </th>
-        </tr>
-    </thead>
-    <tbody>
-        <?php foreach ($registrations as $registration) :
+                    <th class="registration-status-col" style="text-align: center;">
+                        <?php \MapasCulturais\i::_e("Nota preliminar"); ?>
+                    </th>
+                    <th class="registration-status-col" style="text-align: center; width: 20%;">
+                        <?php \MapasCulturais\i::_e("Nota final"); ?>
+                    </th>
+                <?php endif; ?>
+                <th class="registration-status-col" style="text-align: center;width: 20%">
+                    <?php \MapasCulturais\i::_e("Status"); ?>
+                </th>
+            </tr>
+        </thead>
+        <tbody>
+            <?php foreach ($registrations as $registration) :
                 $reg_args = ['registration' => $registration, 'opportunity' => $entity];
             ?>
-        <tr>
-            <?php $this->applyTemplateHook('user-registration-table--registration', 'begin', $reg_args); ?>
-            <td class="registration-status-col" style="text-align: center;">
-                <?php $this->applyTemplateHook('user-registration-table--registration--number', 'begin', $reg_args); ?>
-                <a href="<?php echo $registration->singleUrl ?>"><?php echo $registration->number ?></a>
-                <?php $this->applyTemplateHook('user-registration-table--registration--number', 'end', $reg_args); ?>
-            </td>
-            <td class="registration-agents-col" style="text-align: center;">
-                <?php $this->applyTemplateHook('user-registration-table--registration--agents', 'begin', $reg_args); ?>
-                <p>
-                    <span class="label"><?php \MapasCulturais\i::_e("Responsável"); ?></span><br>
-                    <?php echo htmlentities($registration->owner->name); ?>
-                </p>
-                <?php
+                <tr>
+                    <?php $this->applyTemplateHook('user-registration-table--registration', 'begin', $reg_args); ?>
+                    <td class="registration-status-col" style="text-align: center;">
+                        <?php $this->applyTemplateHook('user-registration-table--registration--number', 'begin', $reg_args); ?>
+                        <a href="<?php echo $registration->singleUrl ?>"><?php echo $registration->number ?></a>
+                        <?php $this->applyTemplateHook('user-registration-table--registration--number', 'end', $reg_args); ?>
+                    </td>
+                    <td class="registration-agents-col" style="text-align: center;">
+                        <?php $this->applyTemplateHook('user-registration-table--registration--agents', 'begin', $reg_args); ?>
+                        <p>
+                            <span class="label"><?php \MapasCulturais\i::_e("Responsável"); ?></span><br>
+                            <?php echo htmlentities($registration->owner->name); ?>
+                        </p>
+                        <?php
                         foreach ($app->getRegisteredRegistrationAgentRelations() as $def) :
                             if (!$entity->useRegistrationAgentRelation($def))
                                 continue;
                         ?>
-                <?php if ($agents = $registration->getRelatedAgents($def->agentRelationGroupName)) : ?>
-                <p>
-                    <span class="label"><?php echo $def->label ?></span><br>
-                    <?php echo htmlentities($agents[0]->name); ?>
-                </p>
-                <?php endif; ?>
-                <?php endforeach; ?>
-                <?php $this->applyTemplateHook('user-registration-table--registration--agents', 'end', $reg_args); ?>
-            </td>
-            <td class="registration-status-col" style="text-align: center;">
-                <?php $this->applyTemplateHook('user-registration-table--registration--status', 'begin', $reg_args); ?>
-                <?php if ($registration->status > 0) : ?>
-                <?php echo $registration->sentTimestamp ? $registration->sentTimestamp->format(\MapasCulturais\i::__('d/m/Y à\s H:i')) : ''; ?>.
-                <?php else : ?>
-                <?php \MapasCulturais\i::_e("Não enviada."); ?><br>
-                <a class="btn btn-small btn-primary"
-                    href="<?php echo $registration->singleUrl ?>"><?php \MapasCulturais\i::_e("Editar e enviar"); ?></a>
-                <?php endif; ?>
-                <?php $this->applyTemplateHook('user-registration-table--registration--status', 'end', $reg_args); ?>
-            </td>
-            <?php if (
+                            <?php if ($agents = $registration->getRelatedAgents($def->agentRelationGroupName)) : ?>
+                                <p>
+                                    <span class="label"><?php echo $def->label ?></span><br>
+                                    <?php echo htmlentities($agents[0]->name); ?>
+                                </p>
+                            <?php endif; ?>
+                        <?php endforeach; ?>
+                        <?php $this->applyTemplateHook('user-registration-table--registration--agents', 'end', $reg_args); ?>
+                    </td>
+                    <td class="registration-status-col" style="text-align: center;">
+                        <?php $this->applyTemplateHook('user-registration-table--registration--status', 'begin', $reg_args); ?>
+                        <?php if ($registration->status > 0) : ?>
+                            <?php echo $registration->sentTimestamp ? $registration->sentTimestamp->format(\MapasCulturais\i::__('d/m/Y à\s H:i')) : ''; ?>.
+                        <?php else : ?>
+                            <?php \MapasCulturais\i::_e("Não enviada."); ?><br>
+                            <a class="btn btn-small btn-primary" href="<?php echo $registration->singleUrl ?>"><?php \MapasCulturais\i::_e("Editar e enviar"); ?></a>
+                        <?php endif; ?>
+                        <?php $this->applyTemplateHook('user-registration-table--registration--status', 'end', $reg_args); ?>
+                    </td>
+                    <?php if (
                         $verifyPublish->publishedRegistrations == true
                         && $typeEvaluation[0]->type->id == 'technical'
                     ) : ?>
-            <td>
-                <?php echo $registration->preliminaryResult;
+                        <td>
+                            <?php echo $registration->preliminaryResult;
                             ?>
-            </td>
+                        </td>
 
-            <?php
+                        <?php
                         //ENTROU COM RECURSO E JA FOI PUBLICADO
                         if ($resource['text'] !== "" && $resource['publish'] == true) {
                             echo '<td>' . $registration->consolidatedResult . '</td>';
@@ -112,47 +113,53 @@ if (!empty($registrations)) {
                                     echo '<td>' . $registration->consolidatedResult . '</td>';
                                 }
                         ?>
-            <?php endif; ?>
-            <?php $this->applyTemplateHook('user-registration-table--registration', 'end', $reg_args); ?>
+                    <?php endif; ?>
+                    <?php $this->applyTemplateHook('user-registration-table--registration', 'end', $reg_args); ?>
 
-            <?php $this->applyTemplateHook('user-registration-table--registration--status', 'begin', $reg_args);
+                    <?php $this->applyTemplateHook('user-registration-table--registration--status', 'begin', $reg_args);
 
                     $status = '';
                     $color = '';
+                    $title = '';
                     switch ($registration->status) {
                         case 0:
                             $status = 'Rascunho';
                             $colorStatus = 'statusrasc';
+                            $title = 'Utilize essa opção para permitir que o responsável edite e reenvie uma inscrição. Ao selecionar esta opção, a inscrição não será mais exibida nesta tabela.';
                             break;
                         case 1:
                             $status = 'Pendente';
                             $colorStatus = 'statuspend';
+                            $title = 'Ainda não avaliada.';
                             break;
                         case 2:
                             $status = 'Inválida';
                             $colorStatus = 'statusinv';
+                            $title = 'Em desacordo com o regulamento (ex. documentação incorreta).';
                             break;
                         case 3:
                             $status = 'Não selecionada';
                             $colorStatus = 'statusrep';
+                            $title = 'Avaliada, mas não selecionada.';
                             break;
                         case 8:
                             $status = 'Suplente';
                             $colorStatus = 'statusespera';
+                            $title = 'Avaliada, mas aguardando vaga.';
                             break;
                         case 10:
                             $status = 'Selecionada';
                             $colorStatus = 'statusap';
+                            $title = 'Avaliada e selecionada.';
                             break;
                     }
                     ?>
-            <td class=" registration-status-col <?php echo $colorStatus; ?>"
-                style="text-align: center; font-size: 11px;">
-                <?php echo $status; ?>
-            </td>
-            <?php $this->applyTemplateHook('user-registration-table--registration', 'end', $reg_args); ?>
-        </tr>
-        <?php endforeach; ?>
-    </tbody>
-</table>
+                    <td class="registration-status-col <?php echo $colorStatus; ?>" style="text-align: center; font-size: 11px;">
+                        <p title="<?php echo $title; ?>"><?php echo $status; ?></p>
+                    </td>
+                    <?php $this->applyTemplateHook('user-registration-table--registration', 'end', $reg_args); ?>
+                </tr>
+            <?php endforeach; ?>
+        </tbody>
+    </table>
 <?php endif; ?>

--- a/layouts/parts/singles/tooltip.php
+++ b/layouts/parts/singles/tooltip.php
@@ -1,0 +1,1 @@
+<p title="<?php echo $title; ?>"><?php echo $chield; ?></p>

--- a/layouts/parts/singles/tooltip.php
+++ b/layouts/parts/singles/tooltip.php
@@ -1,1 +1,6 @@
-<p title="<?php echo $title; ?>"><?php echo $chield; ?></p>
+<!-- 
+  Props: 
+    - title: string com título do tooltip
+    - chield: string conteúdo do tooltip
+ -->
+<p class="hltip" title="<?php echo $title; ?>"><?php echo $chield; ?></p>


### PR DESCRIPTION
Responsáveis:  
@ericsonmoreira 

Linked Issue:  
Close #441

### 📝 Descrição

Atualmente, como candidato de uma oportunidade, ao acessar a página principal de uma oportunidade ao qual estou participando, no quadro Minhas Inscrições, na última coluna de Status, é informado ao usuário o status atual dele naquela oportunidade. Para esta atividade é solicitado que o usuário ao passar o mouse em cima desse status atual seja apresentado a descrição daquele status, conforme as descrições já estabelecidas no mapa.

### 🖥 Passos a passo para teste

1. Acesse o `Mapas da Saúde` com um usuário válido
2. Inscreva-se em uma oportunidade
3. Acesse a página da oportunidade do passo anterior
4. Na aba `Principal` -> tabela `Minhas inscrição` -> coluna `Status` coloque o mouse sobre o status da inscrição e verifique se aparece a mensagem referente àquele status
5. Logado com um usuário `Admin`, altere os status da inscrição para verificar a mensagem que aparece para os outros `status`.

Aqui estão as mensagens esperadas:

- `Rascunho`: O candidato poderá editar e reenviar a sua inscrição.
- `Pendente`: Ainda não avaliada.
- `Inválida`: Em desacordo com o regulamento.
- `Não selecionada`: Avaliada, mas não selecionada.
- `Suplente`: Avaliada, mas aguardando vaga.
- `Selecionada`: Avaliada e selecionada.

### 📎 Observações

Foi adicionado no Thema da Saúde um aquivo chamado `tooltip.php` para reaproveitar a lógica. Modo de uso:

```php
<?php $this->part('singles/tooltip', ['title' => $title, 'chield' => $status]); ?>
```

Onde `title` é a mensagem do `tooltip` e `chield` é o conteúdo.

## 📋 Checklist para criação do PR

- [ ] Testes foram implementados (novos ou não)
- [x] Issue foi definida no PR (Linked Issue na coluna à direita da página)
- [x] Pessoas contribuidoras foram definidas no PR (Assigners no PR)