### PR TITLE
Feature/classificacao automatica

### DIFF
--- a/Theme.php
+++ b/Theme.php
@@ -92,10 +92,8 @@ class Theme extends BaseV1\Theme{
         $app = App::i();
         $notaMedia = intval($note);
 
-        if($notaMedia <= 0 && $note !== "") {
-            
+        if(!empty($note) && $notaMedia >= 0 ) {
             try {
-                
                 // ALTERANDO CANDIDATOS COM NOTA IGUAL OU SUPERIOR A NOTA MINIMA DA OPORTUNIDADE
                 $dql = "SELECT r FROM MapasCulturais\Entities\Registration r 
                 WHERE r.opportunity = {$opportunity} AND r.consolidatedResult >= '{$notaMedia}'";
@@ -111,7 +109,7 @@ class Theme extends BaseV1\Theme{
                     $query      = $app->em->createQuery($dql);
                     $upStatus   = $query->getResult();
                 }
-                return json_encode(['message' => 'success', 'status' => 200]);
+                return json_encode(['message' => 'Alterado status de candidatos nota igual ou maior que a média', 'status' => 200, 'type' => 'success']);
             } catch (\Throwable $th) {
                 return json_encode(['message' => 'error', 'status' => 500]);
             }
@@ -135,11 +133,12 @@ class Theme extends BaseV1\Theme{
                     $query      = $app->em->createQuery($dql);
                     $upStatus   = $query->getResult();
                 }
-                return json_encode(['message' => 'success', 'status' => 200]);
+                return json_encode(['message' => 'Status de candidato alterado, mas com nota a baixo da média', 'status' => 200, 'type' => 'success']);
             } catch (\Throwable $th) {
                 return json_encode(['message' => 'error', 'status' => 500]);
             }
         }
+        return json_encode(['message' => 'Não foi alterado status com base em nota por que não tem nota média.', 'status' => 200, 'type' => 'success']);
     }
     
     protected function _publishAssets() {

--- a/Theme.php
+++ b/Theme.php
@@ -83,45 +83,62 @@ class Theme extends BaseV1\Theme{
             //MUDARÁ O STATUS EM CASO DA AVALIAÇAO SER TÉCNICA
             if($opportunity->evaluationMethodConfiguration->getDefinition()->slug == 'technical') {
                 $setStatus = self::setStatusOwnerOpportunity($this->postData['id'], $opportunity->metadata['registrationMinimumNote']);
+                echo $setStatus;
             }
         });
     }
 
     public static function setStatusOwnerOpportunity($opportunity, $note) {
         $app = App::i();
-        // ALTERANDO CANDIDATOS COM NOTA IGUAL OU SUPERIOR A NOTA MINIMA DA OPORTUNIDADE
-        $dql = "SELECT r FROM MapasCulturais\Entities\Registration r 
-        WHERE r.opportunity = {$opportunity} AND r.consolidatedResult >= '{$note}'";
-        $query      = $app->em->createQuery($dql);
-        $upStatus   = $query->getResult();
-        
-        foreach ($upStatus as $key => $value) {
-            $dql = "";
-            if(!$value->opportunity->publishedRegistrations) {
-               $dql = "UPDATE MapasCulturais\Entities\Registration r 
-                SET r.status = 10 WHERE r.id = {$value->id}";
-            }
-            $query      = $app->em->createQuery($dql);
-            $upStatus   = $query->getResult();
-        }
+        $notaMedia = intval($note);
 
-        //NOTA ABAIXO DA NOTA MINIMA
-        $dql = "SELECT r FROM MapasCulturais\Entities\Registration r 
-        WHERE r.opportunity = {$opportunity} AND r.consolidatedResult < '{$note}'";
-        $query      = $app->em->createQuery($dql);
-        $minimum   = $query->getResult();
-        
-        foreach ($minimum as $key => $value) {
-            $dql = "";
-            if(!$value->opportunity->publishedRegistrations) {
-                $dql = "UPDATE MapasCulturais\Entities\Registration r 
-                SET r.status = 1 WHERE r.id = {$value->id}";
-            }else {
-                $dql = "UPDATE MapasCulturais\Entities\Registration r 
-                SET r.status = 1 WHERE r.id = {$value->id}";
+        if($notaMedia <= 0 && $note !== "") {
+            
+            try {
+                
+                // ALTERANDO CANDIDATOS COM NOTA IGUAL OU SUPERIOR A NOTA MINIMA DA OPORTUNIDADE
+                $dql = "SELECT r FROM MapasCulturais\Entities\Registration r 
+                WHERE r.opportunity = {$opportunity} AND r.consolidatedResult >= '{$notaMedia}'";
+                $query      = $app->em->createQuery($dql);
+                $upStatus   = $query->getResult();
+                //dump($upStatus);
+                foreach ($upStatus as $key => $value) {
+                    $dql = "";
+                    if(!$value->opportunity->publishedRegistrations) {
+                    $dql = "UPDATE MapasCulturais\Entities\Registration r 
+                        SET r.status = 10 WHERE r.id = {$value->id}";
+                    }
+                    $query      = $app->em->createQuery($dql);
+                    $upStatus   = $query->getResult();
+                }
+                return json_encode(['message' => 'success', 'status' => 200]);
+            } catch (\Throwable $th) {
+                return json_encode(['message' => 'error', 'status' => 500]);
             }
-            $query      = $app->em->createQuery($dql);
-            $upStatus   = $query->getResult();
+
+            //NOTA ABAIXO DA NOTA MINIMA
+            try {
+                $dql = "SELECT r FROM MapasCulturais\Entities\Registration r 
+                WHERE r.opportunity = {$opportunity} AND r.consolidatedResult < '{$notaMedia}'";
+                $query      = $app->em->createQuery($dql);
+                $minimum   = $query->getResult();
+                //dump($minimum);
+                foreach ($minimum as $key => $value) {
+                    $dql = "";
+                    if(!$value->opportunity->publishedRegistrations) {
+                        $dql = "UPDATE MapasCulturais\Entities\Registration r 
+                        SET r.status = 1 WHERE r.id = {$value->id}";
+                    }else {
+                        $dql = "UPDATE MapasCulturais\Entities\Registration r 
+                        SET r.status = 1 WHERE r.id = {$value->id}";
+                    }
+                    $query      = $app->em->createQuery($dql);
+                    $upStatus   = $query->getResult();
+                }
+                return json_encode(['message' => 'success', 'status' => 200]);
+            } catch (\Throwable $th) {
+                return json_encode(['message' => 'error', 'status' => 500]);
+            }
         }
     }
     

--- a/Theme.php
+++ b/Theme.php
@@ -80,8 +80,10 @@ class Theme extends BaseV1\Theme{
          */
         $app->hook('POST(opportunity.minimumNote)', function() use($app) {
             $opportunity = $app->repo('Opportunity')->find($this->postData['id']);
-            //dump($opportunity->metadata['registrationMinimumNote']);
-            $setStatus = self::setStatusOwnerOpportunity($this->postData['id'], $opportunity->metadata['registrationMinimumNote']);
+            //MUDARÁ O STATUS EM CASO DA AVALIAÇAO SER TÉCNICA
+            if($opportunity->evaluationMethodConfiguration->getDefinition()->slug == 'technical') {
+                $setStatus = self::setStatusOwnerOpportunity($this->postData['id'], $opportunity->metadata['registrationMinimumNote']);
+            }
         });
     }
 

--- a/assets/js/ng.entity.module.opportunity.js
+++ b/assets/js/ng.entity.module.opportunity.js
@@ -1917,10 +1917,36 @@ module.controller('OpportunityController', ['$scope', '$rootScope', '$location',
         var idEntity = MapasCulturais.entity.id;
         var note = RegistrationService.verifyMinimumNote(idEntity).then(function(response) {
             console.log(response);
+            if(response.data.status == 200 && response.data.message == 'success') {
+                PNotify.removeAll();
+                new PNotify({
+                    title: 'Sucesso!',
+                    text: 'Status alterado com base na média da nota da oportunidade',
+                    type: 'success',
+                    width: "400px",
+                    icon: 'fa fa-check'
+                }); 
+                setTimeout(() => {
+                    window.location.reload(true);
+                }, 1000);
+            }
         });
     }
 
-    $scope.setStatusAproved();
+    $scope.editStatusNote = function() {
+        new PNotify({
+            title: 'Um minuto!',
+            text: 'Já estamos processando a alteração...',
+            type: 'info',
+            width: "400px",
+            icon: 'fa fa-spinner fa-pulse fa-3x fa-fw',
+            shadow: true,
+            hide: false,
+            addclass: 'stack-modal',
+            stack: {'dir1': 'down', 'dir2': 'right', 'modal': true}
+        }); 
+        $scope.setStatusAproved();
+    }
     
     $scope.getStatusNameById = function(id) {
         var statuses = $scope.data.registrationStatusesNames;

--- a/assets/js/ng.entity.module.opportunity.js
+++ b/assets/js/ng.entity.module.opportunity.js
@@ -1916,12 +1916,11 @@ module.controller('OpportunityController', ['$scope', '$rootScope', '$location',
     $scope.setStatusAproved = function() {
         var idEntity = MapasCulturais.entity.id;
         var note = RegistrationService.verifyMinimumNote(idEntity).then(function(response) {
-            console.log(response);
-            if(response.data.status == 200 && response.data.message == 'success') {
+            if(response.data.status == 200 && response.data.type == 'success') {
                 PNotify.removeAll();
                 new PNotify({
                     title: 'Sucesso!',
-                    text: 'Status alterado com base na média da nota da oportunidade',
+                    text: response.data.message,
                     type: 'success',
                     width: "400px",
                     icon: 'fa fa-check'

--- a/layouts/parts/singles/opportunity-registrations--agent-relations.php
+++ b/layouts/parts/singles/opportunity-registrations--agent-relations.php
@@ -43,9 +43,12 @@ $editEntity = $this->controller->action === 'create' || $this->controller->actio
     </p>
 
     <p>
-    <span class="label <?php echo ($entity->isPropertyRequired($entity,"registrationMinimumNote") && $editEntity? 'required': '');?>"><?php \MapasCulturais\i::_e("Informe o valor mínimo de aprovação da oportunidade");?></span><br>
-    <span class="registration-help"><?php \MapasCulturais\i::_e("Informe a nota mínima (a partir de 0) para classificação nesta oportunidade.");?></span><br>
-    <span class="<?php echo $ditable_class ?>" data-edit="registrationMinimumNote" data-original-title="<?php \MapasCulturais\i::esc_attr_e("Informe o valor mínimo de aprovação da oportunidade");?>" data-emptytext="<?php \MapasCulturais\i::esc_attr_e("Insira o número máximo de inscrições por agente responsável");?>"><?php echo $entity->registrationMinimumNote ? $entity->registrationMinimumNote : '0'; ?></span>
-</p>
+    <?php
+    if($entity->evaluationMethodConfiguration->getDefinition()->slug == 'technical') :  ?>
+        <span class="label <?php echo ($entity->isPropertyRequired($entity,"registrationMinimumNote") && $editEntity? 'required': '');?>"><?php \MapasCulturais\i::_e("Informe o valor mínimo de aprovação da oportunidade");?></span><br>
+        <span class="registration-help"><?php \MapasCulturais\i::_e("Informe a nota mínima (a partir de 0) para classificação nesta oportunidade.");?></span><br>
+        <span class="<?php echo $ditable_class ?>" data-edit="registrationMinimumNote" data-original-title="<?php \MapasCulturais\i::esc_attr_e("Informe o valor mínimo de aprovação da oportunidade");?>" data-emptytext="<?php \MapasCulturais\i::esc_attr_e("Insira o número máximo de inscrições por agente responsável");?>"><?php echo $entity->registrationMinimumNote ? $entity->registrationMinimumNote : '0'; ?></span>
+    <?php endif; ?>
+    </p>
 </div>
 <!-- #registration-agent-relations -->

--- a/layouts/parts/singles/opportunity-registrations--agent-relations.php
+++ b/layouts/parts/singles/opportunity-registrations--agent-relations.php
@@ -47,7 +47,7 @@ $editEntity = $this->controller->action === 'create' || $this->controller->actio
     if($entity->evaluationMethodConfiguration->getDefinition()->slug == 'technical') :  ?>
         <span class="label <?php echo ($entity->isPropertyRequired($entity,"registrationMinimumNote") && $editEntity? 'required': '');?>"><?php \MapasCulturais\i::_e("Informe o valor mínimo de aprovação da oportunidade");?></span><br>
         <span class="registration-help"><?php \MapasCulturais\i::_e("Informe a nota mínima (a partir de 0) para classificação nesta oportunidade.");?></span><br>
-        <span class="<?php echo $ditable_class ?>" data-edit="registrationMinimumNote" data-original-title="<?php \MapasCulturais\i::esc_attr_e("Informe o valor mínimo de aprovação da oportunidade");?>" data-emptytext="<?php \MapasCulturais\i::esc_attr_e("Insira o número máximo de inscrições por agente responsável");?>"><?php echo $entity->registrationMinimumNote ? $entity->registrationMinimumNote : '0'; ?></span>
+        <span class="<?php echo $ditable_class ?>" data-edit="registrationMinimumNote" data-original-title="<?php \MapasCulturais\i::esc_attr_e("Informe o valor mínimo de aprovação da oportunidade");?>" data-emptytext="<?php \MapasCulturais\i::esc_attr_e("Insira a nota média");?>"><?php echo $entity->registrationMinimumNote ? $entity->registrationMinimumNote : '0'; ?></span>
     <?php endif; ?>
     </p>
 </div>

--- a/layouts/parts/singles/opportunity-registrations--agent-relations.php
+++ b/layouts/parts/singles/opportunity-registrations--agent-relations.php
@@ -47,7 +47,13 @@ $editEntity = $this->controller->action === 'create' || $this->controller->actio
     if($entity->evaluationMethodConfiguration->getDefinition()->slug == 'technical') :  ?>
         <span class="label <?php echo ($entity->isPropertyRequired($entity,"registrationMinimumNote") && $editEntity? 'required': '');?>"><?php \MapasCulturais\i::_e("Informe o valor mínimo de aprovação da oportunidade");?></span><br>
         <span class="registration-help"><?php \MapasCulturais\i::_e("Informe a nota mínima (a partir de 0) para classificação nesta oportunidade.");?></span><br>
-        <span class="<?php echo $ditable_class ?>" data-edit="registrationMinimumNote" data-original-title="<?php \MapasCulturais\i::esc_attr_e("Informe o valor mínimo de aprovação da oportunidade");?>" data-emptytext="<?php \MapasCulturais\i::esc_attr_e("Insira a nota média");?>"><?php echo $entity->registrationMinimumNote ? $entity->registrationMinimumNote : '0'; ?></span>
+        <span class="<?php echo $ditable_class ?>" data-edit="registrationMinimumNote" data-original-title="<?php \MapasCulturais\i::esc_attr_e("Informe o valor mínimo de aprovação da oportunidade");?>" data-emptytext="<?php \MapasCulturais\i::esc_attr_e("Insira a nota média");?>"><?php
+        if($entity->registrationMinimumNote == ''){
+            echo 'Sem nota';
+        }else{
+            echo $entity->registrationMinimumNote;
+        }
+        ?></span>
     <?php endif; ?>
     </p>
 </div>

--- a/layouts/parts/singles/opportunity-registrations--tables--manager.php
+++ b/layouts/parts/singles/opportunity-registrations--tables--manager.php
@@ -69,6 +69,11 @@ use MapasCulturais\i;
         Mudar status para selecionada (Pendente)
         <input type="checkbox" name="checkselected" id="checkselected" ng-click="setStatusToSelected()" style="margin-left: 10px; margin-right: 10px;">
     </div>
+    <div style="float: left;" class="selected-opportunity">
+        <button class="btn btn-default" title="Atualiza o status do candidato com base na nota da oportunidade" ng-click="editStatusNote()">
+        <i class="fa fa-refresh" aria-hidden="true"></i>
+        </button>
+    </div>
     <table id="registrations-table" class="js-registration-list registrations-table" ng-class="{'no-options': data.entity.registrationCategories.length === 0, 'no-attachments': data.entity.registrationFileConfigurations.length === 0, 'registrations-results': data.entity.published, 'fullscreen': data.fullscreenTable}">
         <!-- adicionar a classe registrations-results quando resultados publicados-->
         <thead>


### PR DESCRIPTION
### Autor
@Junior-Shyko 

### Contexto
A classificação automática por nota de corte estava atualizando o status do candidato com base na nota média da oportunidade em todo o momento que a página era atualizada, sendo assim, quando mudasse o status do candidato, o status dele se alterava novamente.

Foi corrigido isso, agora somente após um click o status do candidato muda com base na nota média da oportunidade.

### Issue
#168 

### Testes
Todos os critérios de aceitação da issue