### PR TITLE
Correção de Bug na página Minhas Inscrições

### DIFF
--- a/views/panel/registrations.php
+++ b/views/panel/registrations.php
@@ -7,13 +7,15 @@ error_reporting(E_ALL);
     $drafts = $app->repo('Registration')->findByUser($app->user, Registration::STATUS_DRAFT);
     $sent = $app->repo('Registration')->findByUser($app->user, 'sent');
     
-    // ORDENANDO O ARRAY POR DATA DE ENVIO DA INSCRIÇÃO EM ORDEM DECRESCENTE
-    if($sent):
-        foreach ($sent as $key => $value){
-        $dateTime[] = $value->sentTimestamp->format('d-m-Y H:i:s');
-        }
-        array_multisort($dateTime,SORT_DESC,SORT_STRING,$sent);   
+  // ORDENANDO O ARRAY POR DATA DE ENVIO DA INSCRIÇÃO EM ORDEM DECRESCENTE
+  if($sent):
+    if (isset($dateTime)):
+    foreach ($sent as $key => $value){
+    $dateTime[] = $value->sentTimestamp->format('d-m-Y H:i:s');
+    }
+    array_multisort($dateTime,SORT_DESC,SORT_STRING,$sent);   
     endif;
+  endif;
  ?>
 
 <div class="panel-list panel-main-content">


### PR DESCRIPTION
Responsáveis:  
@FernandaNascimento26 
Linked Issue:  
Close #192

### 📝 Descrição

Correção de um bug na página de inscrições que apresentava um erro do PHP ao invés da lista de inscrições do candidato. 
Esse erro é causado quando o campo **sent_timestamp** é vazio (nulo).

Para resolver foi adicionado uma verificação de exstencia do campo. 

### 🖥 Passos a passo para teste

> Deve haver inscrição enviada.

1. No painel de controle ou menu suspenso clicar no link **Minhas Inscrições**
2. Verificar se é exibida na tela a lista de inscrições enviadas

## 📋 Checklist para criação do PR

- [ ] Testes foram implementados (novos ou não)
- [x] Issue foi definida no PR (Linked Issue na coluna à direita da página)
- [x] Pessoas contribuidoras foram definidas no PR (Assigners no PR)
