### PR TITLE
#196 #197 suprimi editais e oportunidades e inscrições com projetos v…

### DIFF
--- a/Theme.php
+++ b/Theme.php
@@ -293,7 +293,7 @@ class Theme extends BaseV1\Theme{
                 'verificados' => [
                     'label' => $this->dict('search: verified results', false),
                     'tag' => $this->dict('search: verified', false),
-                    'placeholder' => $this->dict('search: display only verified results', false),
+                    'placeholder' => i::__('São exibidas apenas as seleções da ESP'),
                     'fieldType' => 'checkbox-verified',
                     'addClass' => 'verified-filter',
                     'isArray' => false,

--- a/layouts/parts/header-main-nav.php
+++ b/layouts/parts/header-main-nav.php
@@ -65,35 +65,12 @@
             <?php $this->applyTemplateHook('nav.main.projects','before'); ?>
             <li id="entities-menu-project"
                 ng-click="tabClick('project')">
-                <a href="<?php if ($this->controller->action !== 'search') echo $app->createUrl('site', 'search') . '##(global:(enabled:(project:!t),filterEntity:project,viewMode:list))'; ?>">
+                <a href="<?php if ($this->controller->action !== 'search') echo $app->createUrl('site', 'search') . '##(global:(enabled:(project:!t),filterEntity:project,viewMode:list),project:(filters:(\'@verified\':!t)))'; ?>">
                     <div class="icon icon-project"></div>
-                    <div class="menu-item-label"><?php $this->dict('entities: Projects') ?></div>
+                    <div class="menu-item-label"><?php \MapasCulturais\i::_e("Inscrições");?></div>
                 </a>
             </li>
             <?php $this->applyTemplateHook('nav.main.projects','after'); ?>
-        <?php endif; ?>
-            
-        <?php if($app->isEnabled('opportunities')): ?>
-            <?php $this->applyTemplateHook('nav.main.opportunities','before'); ?>
-            <li id="entities-menu-opportunity"
-                ng-click="tabClick('opportunity')">
-                <a href="<?php echo $app->createUrl('busca').'?type=opp##(global:(enabled:(opportunity:!t),filterEntity:opportunity,viewMode:list))'; ?>">
-                    <div class="icon icon-opportunity"></div>
-                    <div class="menu-item-label"><?php $this->dict('entities: Opportunities') ?></div>
-                </a>
-            </li>
-            <?php $this->applyTemplateHook('nav.main.opportunities','after'); ?>
-        <?php endif; ?>
-
-        <?php if($app->isEnabled('opportunities')): ?>
-            <li id="entities-menu-edital"
-                ng-click="tabClick('opportunity')">
-                <a title="Editais e Concursos" href="<?php echo $app->createUrl('busca').'?type=edital##(global:(enabled:(opportunity:!t),filterEntity:opportunity,viewMode:list,type:edital))'; ?>">
-                    <div><i class="fa fa-file-text" aria-hidden="true"></i></div>
-                    <div class="menu-item-label" style="margin-top: 7px;"><?php \MapasCulturais\i::_e("Editais");?></div>
-                </a>
-            </li>
-            <?php $this->applyTemplateHook('nav.main.opportunities','after'); ?>
         <?php endif; ?>
     </ul>
     <!--.menu.entities-menu-->


### PR DESCRIPTION
Responsáveis:  
@victorMagalhaesPacheco 

Linked Issue:  
Close #196 #197

### Descrição

Oculta o menu oportunidades e editais, realiza mudança de projetos para Inscrições para ser aplicado os filtros por selos.

### Passos a passo para teste

1. Acessar o mapa da Saúde
2. Acessar o menu Inscrições
3. Automaticamente será apresentado os projetos com os SELOS verificados da ESP
4. Ao desabilitar a verificação das oportunidades, é apresentado todos os editais

## Checklist para criação do PR

- [ ] Testes foram implementados (novos ou não)
- [x] Issue foi definida no PR (Linked Issue na coluna à direita da página)
- [x] Pessoas contribuidoras foram definidas no PR (Assigners no PR)
