### PR TITLE
#205 aplicando bloqueio de inscrições para admin, dono da oportunidad…

### DIFF
--- a/layouts/parts/singles/opportunity-registrations--form.php
+++ b/layouts/parts/singles/opportunity-registrations--form.php
@@ -12,6 +12,7 @@ $userRelation = $entity->evaluationMethodConfiguration->getUserRelation($user);
 
 $btnHideShow = false;
 
+
 if (strpos($url_atual, 'opportunity') !== false) {
     $btnHideShow = true;
 } else {
@@ -22,7 +23,7 @@ if ($entity->isRegistrationOpen()) : ?>
     <?php if ($app->auth->isUserAuthenticated()) : ?>
 
         <!-- // CASO ESSE USUÁRIO FOI ALGUM AVALIADOR ou for o dono da entidade, então O FORM NAO APARECERÁ PARA ELE  -->
-        <?php if (empty($userRelation) && !($user->id == $entity->owner->userId)) : ?>
+        <?php if (!($entity->canUser('modify')) && empty($userRelation)) : ?>
             <form class="registration-form clearfix">
                 <p class="registration-help white-top" style="font-size: 14px;"><?php \MapasCulturais\i::_e("Para iniciar sua inscrição, selecione o agente responsável. Ele deve ser um agente individual (pessoa física), com um CPF válido preenchido."); ?></p>
                 <div class="registration-form-content">


### PR DESCRIPTION
Responsáveis:  
@victorMagalhaesPacheco 

Linked Issue:  #205 

### Descrição

O campo de inscrição deve ser bloqueado para o usuário dono, admin da oportunidade e avaliador da oportunidade.

### Passos a passo para teste

1. Criar um projeto
2. Criar uma oportunidade vinculada ao projeto
3. Habilitar as inscrições da oportunidade
4. Adicionar um administrador na oportunidade
5. Adicionar um avaliador para oportunidade
6. Acessar como usuário dono da oportunidade e verificar que o campo de inscrição não aparece
7. Acessar como usuário admin da oportunidade e verificar que o campo de inscrição não aparece
8. Acessar como usuário avaliador da oportunidade e verificar que o campo de inscrição não aparece

### Observações

Não se aplica
