### PR TITLE
Permitir a possibilidade de recurso em fases distintas

### DIFF
--- a/Theme.php
+++ b/Theme.php
@@ -49,6 +49,10 @@ class Theme extends BaseV1\Theme{
         $app->hook("template(<<*>>.edit.tabs):end", function() use($app){
             $app->view->enqueueScript('app', 'resources-meta', 'js/resources-meta.js');
         });
+        //CHAMADA DO TEMPLATE DE RECURSOS 
+        $app->hook('view.partial(claim-configuration).params', function($__data, &$__template){
+            $__template = 'singles/opportunity-resources--form';
+        });
        
         $app->hook('GET(opportunity.evaluationCandidate)', function() use($app){
             $app = App::i();

--- a/layouts/parts/singles/opportunity-registrations--categories.php
+++ b/layouts/parts/singles/opportunity-registrations--categories.php
@@ -1,6 +1,5 @@
 <?php
    use MapasCulturais\i;
-   Use Saude\Entities\Resources;
 
    $can_edit = $entity->canUser('modifyRegistrationFields');
    
@@ -12,21 +11,6 @@
    } else {
        $registration_categories = is_array($entity->registrationCategories) ? implode('; ', $entity->registrationCategories) : '';
    }
-
-   //VERIFICANDO SE TEM RECURSO HABILITADO
-   $enabledDiv = 'hidden';
-   $selectedEnabled  = 'selected';
-   $selectedDisabled = '';
-   $resource = $app->repo('OpportunityMeta')->findBy([
-      'key' => 'claimDisabled',
-      'owner' => $entity->id
-   ]);
-   if(isset($resource[0]) && $resource[0]->value == 0){
-      $enabledDiv = 'visible';
-      $selectedEnabled  = '';
-      $selectedDisabled = 'selected';
-   }
-   $period = Resources::getTimeOpportunityResource($entity->id);
 ?>
 <div id="registration-categories" class="registration-fieldset">
    <h4><?php \MapasCulturais\i::_e("Opções");?></h4>
@@ -53,54 +37,6 @@
       <span class="js-editable" data-edit="opportunity_taxonomia" data-original-title="<?php \MapasCulturais\i::esc_attr_e('Tipos de unidade');?>"><?php echo $entity->opportunity_taxonomia; ?>
       </span>
    </p>
-   <p><hr>
-      <h4><?php \MapasCulturais\i::_e("Recurso");?></h4>
-   </p>
-   <p class="registration-help">
-      Espaço para configurar se a oportunidade receberá a modalidade de recurso.
-   </p>
-   <p>
-   <div class="panel panel-default">
-      <div class="panel-heading"> <label><?php i::_e("Formulário para recursos");?></label></div>
-      <div class="panel-body">
-         <form id="resourceFormData">
-            <select id="resourceOptions" name="claimDisabled" class="form-control" name="resourceOptions">
-               <option value="0" <?php echo $selectedDisabled; ?>>
-                  <?php i::_e('Habilitar formulário de Recurso');?>
-               </option>
-               <option <?php echo $selectedEnabled; ?> value="1">
-                  <?php i::_e('Desabilitar formulário de Recurso');?>
-               </option>
-            </select>
-            <div id="insertData" class="<?php echo $enabledDiv; ?>">
-               <div class="form-group">
-                  <label for="hora-inicial">Data de início </label>
-                  <input type="text" class="date form-control dateResource" name="date-initial" value="<?php echo $period['datIni']; ?>">
-               </div>
-               <div class="">
-                  <label for="hora-inicial">Hora de início </label>
-                  <input type="text" class="time form-control" name="hour-initial" value="<?php echo $period['horIni']; ?>">
-               </div>
-               <div class="form-group">
-                  <label for="data-final">Data final </label>
-                  <input type="text" class="date form-control dateResource" name="date-final" value="<?php echo $period['datFim']; ?>">
-               </div>
-               <div class="form-group">
-                  <label for="hora-final">Hora final </label>
-                  <input type="text" class="time form-control" name="hour-final" value="<?php echo $period['horFim']; ?>">
-               </div>
-               <div class="form-group">
-                  <input type="hidden" name="opportunity" id="opportunityIdResources">
-                  <button class="btn btn-primary" id="buttonSendData">
-                  <i class="fa fa-save"></i> Salvar
-                  </button>
-               </div>
-            </div>
-         </form>
-      </div>
-   </div>
-   </p>
-   <p>
       <div>
       <?php $this->applyTemplateHook('tabs-content-tiebreaker','begin'); ?>
       <?php $this->applyTemplateHook('tabs-content-tiebreaker','end'); ?>

--- a/layouts/parts/singles/opportunity-resources--form.php
+++ b/layouts/parts/singles/opportunity-resources--form.php
@@ -1,0 +1,72 @@
+<?php
+   use MapasCulturais\i;
+   Use Saude\Entities\Resources;
+
+   $entity =  $this->controller->requestedEntity;
+
+   $can_edit = $entity->canUser('modifyRegistrationFields');
+   
+   $editable_class = $can_edit ? 'js-editable' : '';
+
+   //VERIFICANDO SE TEM RECURSO HABILITADO
+   $enabledDiv = 'hidden';
+   $selectedEnabled  = 'selected';
+   $selectedDisabled = '';
+   $resource = $app->repo('OpportunityMeta')->findBy([
+      'key' => 'claimDisabled',
+      'owner' => $entity->id
+   ]);
+   if(isset($resource[0]) && $resource[0]->value == 0){
+      $enabledDiv = 'visible';
+      $selectedEnabled  = '';
+      $selectedDisabled = 'selected';
+   }
+   $period = Resources::getTimeOpportunityResource($entity->id);
+?>
+
+<p>
+    <hr>
+<h4><?php i::_e("Recurso"); ?></h4>
+</p>
+<p class="registration-help">
+    Espaço para configurar se a oportunidade receberá a modalidade de recurso.
+</p>
+<div class="panel panel-default">
+    <div class="panel-heading"> <label><?php i::_e("Formulário para recursos"); ?></label></div>
+    <div class="panel-body">
+        <form id="resourceFormData">
+            <select id="resourceOptions" name="claimDisabled" class="form-control" name="resourceOptions">
+                <option value="0" <?php echo $selectedDisabled; ?>>
+                    <?php i::_e('Habilitar formulário de Recurso'); ?>
+                </option>
+                <option <?php echo $selectedEnabled; ?> value="1">
+                    <?php i::_e('Desabilitar formulário de Recurso'); ?>
+                </option>
+            </select>
+            <div id="insertData" class="<?php echo $enabledDiv; ?>">
+                <div class="form-group">
+                    <label for="hora-inicial">Data de início </label>
+                    <input type="text" class="date form-control dateResource" name="date-initial" value="<?php echo $period['datIni']; ?>">
+                </div>
+                <div class="">
+                    <label for="hora-inicial">Hora de início </label>
+                    <input type="text" class="time form-control" name="hour-initial" value="<?php echo $period['horIni']; ?>">
+                </div>
+                <div class="form-group">
+                    <label for="data-final">Data final </label>
+                    <input type="text" class="date form-control dateResource" name="date-final" value="<?php echo $period['datFim']; ?>">
+                </div>
+                <div class="form-group">
+                    <label for="hora-final">Hora final </label>
+                    <input type="text" class="time form-control" name="hour-final" value="<?php echo $period['horFim']; ?>">
+                </div>
+                <div class="form-group">
+                    <input type="hidden" name="opportunity" id="opportunityIdResources">
+                    <button class="btn btn-primary" id="buttonSendData">
+                        <i class="fa fa-save"></i> Salvar
+                    </button>
+                </div>
+            </div>
+        </form>
+    </div>
+</div>


### PR DESCRIPTION
Responsáveis:  
@FernandaNascimento26 
Linked Issue:  
Close #214  

### 📝 Descrição

Permitir que o administrador de uma oportunidade insira recursos em todas as fases de um edital.

### 🖥 Passos a passo para teste

1. Ao criar uma oportunidade, adicionar diferentes fases;
2. Verificar se é exibido o formulário de recurso em todas as fases criadas;
3. Habilitar o formulário de recurso, adicionando as informações de data e hora de início de fim do periodo de recurso;

## 📋 Checklist para criação do PR

- [ ] Testes foram implementados (novos ou não)
- [x] Issue foi definida no PR (Linked Issue na coluna à direita da página)
- [x] Pessoas contribuidoras foram definidas no PR (Assigners no PR)

## Observações

- Algumas alterações como centralização dos ícones do header foram implementadas porém quebrava a responsividade da aplicação , então foi comunicado e alinhado com a equipe de designer que essa alteração em específico não seria realizada. 

