### PR TITLE
#220 Adicionar Lazy Loading nos botoes de compartilhamento nas redes …

### DIFF
--- a/layouts/parts/redes-sociais.php
+++ b/layouts/parts/redes-sociais.php
@@ -1,4 +1,4 @@
-<div class="widget">
+<div class="widget redes-sociais" style="display:none">
     <h3><?php \MapasCulturais\i::_e("Compartilhar");?></h3>
     <!-- LinkedIn -->
     <div>
@@ -56,3 +56,9 @@
     <?php endif; ?>
 </div>
 <?php endif; ?>
+
+<script>
+    jQuery(window).load(function () { 
+        $(".redes-sociais").toggle("fast");
+    });
+</script>


### PR DESCRIPTION
Responsáveis:   
@lucastandy 
 
Linked Issue:   
 
#220 
 
### Descrição 
 
Atualmente no mapa da saúde o mesmo carrega os botões das redes sociais para compartilhamento, dependendo do bloqueio de acesso, a página pode demorar 15 segundos tentando conectar os botões na página. 

 
### 🖥 Passo a passo para teste: 
 
1. Acessar  as páginas que contém botões de rede social dentro da rede da ESP;
2. Verificar se os botões aparecem após o carregamento total da página.