### PR TITLE
232 ajustes recurso oportunidade simplificada e documental

### DIFF
--- a/Controllers/Resources.php
+++ b/Controllers/Resources.php
@@ -97,21 +97,25 @@ class Resources extends \MapasCulturais\Controller{
         $reply->resourceStatus = $this->putData['resource_status'];
         $reply->resourceDateReply = $date;
 
+        $reg = $app->repo('Registration')->find($reply->registrationId->id);
+
+        //ALTERAR O STATUS DO CANDIDATO
+        //VERIFICA SE RECEBEU A OPÇÃO DE HABILITAR O CANDIDATO PARA A FASE SEGUINTE 
+        if(isset($this->putData['status']) && $this->putData['status'] == '1') {
+            //REALIZA A ALTERAÇÃO NO BANCO PARA O STATUS SELECIONADO
+            $dql = "UPDATE MapasCulturais\Entities\Registration r 
+            SET r.status = 10 WHERE r.id = {$reg->id}";
+            $query = $app->em->createQuery($dql);
+            $query->getResult();
+        }
+
         //ALTERAR A NOTA FINAL
         if(!empty($this->putData['new_consolidated_result'])) {
             $max = EntitiesResources::maxPoint($reply->opportunityId->evaluationMethodConfiguration->id);
 
-            $reg = $app->repo('Registration')->find($reply->registrationId->id);
             if($this->putData['new_consolidated_result'] > $max) {
                 $this->json(['title' => 'Ops!','message' => 'A nova nota não pode ser maior que a nota máxima', 'type' => 'error'], 401);
             }else{
-                
-                if(isset($this->putData['status']) && $this->putData['status'] == '1') {
-                    $dql = "UPDATE MapasCulturais\Entities\Registration r 
-                    SET r.status = 10 WHERE r.id = {$reg->id}";
-                    $query      = $app->em->createQuery($dql);
-                    $query->getResult();
-                }
                 $reg->consolidatedResult = $this->putData['new_consolidated_result'];
                 $app->em->persist($reg);
             }

--- a/Controllers/Resources.php
+++ b/Controllers/Resources.php
@@ -99,7 +99,7 @@ class Resources extends \MapasCulturais\Controller{
 
         //ALTERAR A NOTA FINAL
         if(!empty($this->putData['new_consolidated_result'])) {
-            $max = EntitiesResources::maxPoint($reply->opportunityId->id);
+            $max = EntitiesResources::maxPoint($reply->opportunityId->evaluationMethodConfiguration->id);
 
             $reg = $app->repo('Registration')->find($reply->registrationId->id);
             if($this->putData['new_consolidated_result'] > $max) {

--- a/Controllers/Resources.php
+++ b/Controllers/Resources.php
@@ -95,6 +95,7 @@ class Resources extends \MapasCulturais\Controller{
         $reply = $app->em->find('Saude\Entities\Resources', $this->putData['resource_id']);
         $reply->resourceReply = $this->putData['resource_reply'];
         $reply->resourceStatus = $this->putData['resource_status'];
+        $reply->decisao_recurso = $this->putData['status'];
         $reply->resourceDateReply = $date;
 
         $reg = $app->repo('Registration')->find($reply->registrationId->id);

--- a/Entities/Resources.php
+++ b/Entities/Resources.php
@@ -267,11 +267,11 @@ class Resources extends \MapasCulturais\Entity{
         }
         $dt = $date.' '.$hour;
         $dtFim = $dateEnd .' ' .$hourEnd;
-        $dateinit = \DateTime::createFromFormat('Y-m-d H:i:s', $dt);
+        $dateinit = \DateTime::createFromFormat('Y-m-d H:i', $dt);
         //dump($dateinit);
         $now = new DateTime('now');
         //dump($now);
-        $dateFinal = \DateTime::createFromFormat('Y-m-d H:i:s', $dtFim);
+        $dateFinal = \DateTime::createFromFormat('Y-m-d H:i', $dtFim);
 
         $open = false;
         $close = false;

--- a/Entities/Resources.php
+++ b/Entities/Resources.php
@@ -101,6 +101,13 @@ class Resources extends \MapasCulturais\Entity{
      */
     protected $replyPublish = false;
 
+    /**
+     * @var integer
+     *
+     * @ORM\Column(name="decisao_recurso", type="integer")
+     */
+    protected $decisao_recurso;
+
     public static function allResource() {
         $app = App::i();
         $userId = $app->user->profile->id;

--- a/Entities/Resources.php
+++ b/Entities/Resources.php
@@ -196,20 +196,29 @@ class Resources extends \MapasCulturais\Entity{
     /**
      * Verifica a pontuação máxima configurada na avaliação para a banca poder alterar a nota
      *
-     * @param [integer] $opportunity id da Oportunidade
+     * @param [integer] $evaluationMethodConfigurationId id da Oportunidade
      * @return integer
      */
-    public static function maxPoint($opportunity) {
+    public static function maxPoint($evaluationMethodConfigurationId) {
         $app = App::i();
         $pointMax = $app->repo("EvaluationMethodConfigurationMeta")->findBy([
-            'owner' => $opportunity,
+            'owner' => $evaluationMethodConfigurationId,
             'key' => 'criteria'
         ]);
-        $spotsToarray = json_decode($pointMax[0]->value);
+
+        $spotsToarray = [];
+        if (count($pointMax)) {
+            $spotsToarray = json_decode($pointMax[0]->value);
+        }
+        
         $spots = 0;
+        /**
+         * @todo deve realizar o calculo da nota máxima possível para a oportunidade
+         */
         foreach ($spotsToarray as $value) {
             $spots = ($spots + $value->max);
         }
+
         return $spots;
     }
 

--- a/assets/js/ng.resource.js
+++ b/assets/js/ng.resource.js
@@ -1,6 +1,4 @@
 $(document).ready(function () {
-    //OCULTANDO CAMPO NO FORMULÁRIO DE RESPOSTA
-    $("#divDeferido").hide();
     
     getAllResource();
     $("#formSendResource").submit(function (e) { 
@@ -37,6 +35,7 @@ $(document).ready(function () {
         event.preventDefault();
         var form = $("#formReplyResource").serialize();
         var idResource = $("#resource_id").val();
+
         $.ajax({
             type: "PUT",
             url: MapasCulturais.baseURL+'recursos/replyResource/'+idResource,
@@ -70,8 +69,15 @@ $(document).ready(function () {
     $('#resource_status').on('change', function() {
         var type = this.value;
         if(type == 'Deferido' || type == 'ParcialmenteDeferido') {
+            $("#indeferido_reply").hide();
             $("#divDeferido").show();
-            pointMax(MapasCulturais.entity.object.id);
+
+            if ($("#evaluationMethod").val() == 'technical') {
+                pointMax(MapasCulturais.entity.object.id);
+            }           
+        }else if(type == 'Indeferido'){
+            $("#divDeferido").show();
+            $("#indeferido_reply").show();
         }else{
             $("#divDeferido").hide();
         }
@@ -316,8 +322,10 @@ function pointMax(opportunity) {
         data: {opportunityId: opportunity},
         dataType: "json",
         success: function (response) {
-            $("#infoNotaMaxima").html("Gostariamos de lhe lembrar que a nota máxima de pontuação é de: " + response.message);
-            $("#new_consolidated_result").attr('max' , response.message);
+            if (response.type == 'technical') {
+                $("#infoNotaMaxima").html("Gostariamos de lhe lembrar que a nota máxima de pontuação é de: " + response.message);
+                $("#new_consolidated_result").attr('max' , response.message);
+            }          
         }
     });
 }

--- a/assets/js/ng.resource.js
+++ b/assets/js/ng.resource.js
@@ -67,7 +67,6 @@ $(document).ready(function () {
     //habilitando div para nota
     $('#resource_status').on('change', function() {
         var type = this.value;
-        $('#button-send-resource').prop("disabled", false);
         if(type == 'Deferido' || type == 'ParcialmenteDeferido') {
             hideIfDeferido();
             if ($("#evaluationMethod").val() == 'technical') {

--- a/assets/js/ng.resource.js
+++ b/assets/js/ng.resource.js
@@ -147,7 +147,7 @@ function inforesourceReply(resourceId) {
             $("#resourceText").html('<strong>Recurso: </strong>'+response.resourceText);
             $("#resource_id").val(response.id);
             if(response.resourceStatus == 'Aguardando'){
-                $('#resource_status option[value=Aguardando]').attr('selected','selected');
+                $('#resource_status').val('default');
             }else{
                 if(response.resourceStatus == 'Deferido' || response.resourceStatus == 'ParcialmenteDeferido'){
                     hideIfDeferido();

--- a/assets/js/ng.resource.js
+++ b/assets/js/ng.resource.js
@@ -49,7 +49,6 @@ $(document).ready(function () {
                 });
                 var inst = $('[data-remodal-id=modal-resposta-recurso]').remodal();
                 setTimeout(() => {
-                    // $( "#resource_status option:selected" ).text('--Selecione--');
                     inst.close();
                     location.reload();
                 }, 1000);
@@ -143,11 +142,11 @@ function inforesourceReply(resourceId) {
     }
     $.get(MapasCulturais.baseURL+'recursos/inforesourceReply', data,
         function (response) {
-            $("#resource_reply").val(response.resourceReply)
+            $('#resource_status').val(response.resourceStatus);
+            $("#resource_reply").val(response.resourceReply);
             $("#resourceText").html('<strong>Recurso: </strong>'+response.resourceText);
             $("#resource_id").val(response.id);
             if(response.resourceStatus == 'Aguardando'){
-                //$( "#resource_status option:selected" ).text('--Selecione--');
                 $('#resource_status option[value=Aguardando]').attr('selected','selected');
             }else{
                 if(response.resourceStatus == 'Deferido' || response.resourceStatus == 'ParcialmenteDeferido'){
@@ -157,9 +156,6 @@ function inforesourceReply(resourceId) {
                 }else{
                     hideIfDefault();
                 }
-                $('#resource_status option[value='+response.resourceStatus+']').attr('selected','selected');
-                console.log();
-                // $( "#resource_status option:selected" ).text(response.resourceStatus);
             }
             
         }

--- a/assets/js/ng.resource.js
+++ b/assets/js/ng.resource.js
@@ -96,12 +96,17 @@ function showModalResource(reg, opp, age, oppName) {
     $("#opportunityNameLabel").html(oppName)
 }
 
-function showModalReply(resourceId, opportunity, oppName, note) {
+function showModalReply(resourceId, opportunity, oppName, recurso_sit,note) {
     $("#replyOpportunityNameLabel").html('');
     $("#resourceText").html('');
     $("#resource_id").val(0);
     $("#replyOpportunityNameLabel").html(oppName);
     $("#consolidated_result").val(note);
+    if(!recurso_sit){
+        recurso_sit=0;
+    }
+    //Pega a decisão do recurso
+    $("#decisao_recurso").val(recurso_sit);
 
     $.ajax({
         type: "POST",

--- a/assets/js/ng.resource.js
+++ b/assets/js/ng.resource.js
@@ -68,6 +68,7 @@ $(document).ready(function () {
     //habilitando div para nota
     $('#resource_status').on('change', function() {
         var type = this.value;
+        $('#button-send-resource').prop("disabled", false);
         if(type == 'Deferido' || type == 'ParcialmenteDeferido') {
             $("#indeferido_reply").hide();
             $("#divDeferido").show();
@@ -76,6 +77,9 @@ $(document).ready(function () {
                 pointMax(MapasCulturais.entity.object.id);
             }           
         }else if(type == 'Indeferido'){
+            $("#divDeferido").hide();
+        }else {
+            $('#button-send-resource').prop("disabled", true);
             $("#divDeferido").hide();
         }
     });

--- a/assets/js/ng.resource.js
+++ b/assets/js/ng.resource.js
@@ -76,13 +76,12 @@ $(document).ready(function () {
                 pointMax(MapasCulturais.entity.object.id);
             }           
         }else if(type == 'Indeferido'){
-            $("#divDeferido").show();
-            $("#indeferido_reply").show();
-        }else{
             $("#divDeferido").hide();
         }
     });
+
 });
+
 
 
 

--- a/assets/js/ng.resource.js
+++ b/assets/js/ng.resource.js
@@ -70,17 +70,14 @@ $(document).ready(function () {
         var type = this.value;
         $('#button-send-resource').prop("disabled", false);
         if(type == 'Deferido' || type == 'ParcialmenteDeferido') {
-            $("#indeferido_reply").hide();
-            $("#divDeferido").show();
-
+            hideIfDeferido();
             if ($("#evaluationMethod").val() == 'technical') {
                 pointMax(MapasCulturais.entity.object.id);
             }           
         }else if(type == 'Indeferido'){
-            $("#divDeferido").hide();
+            hideIfIndeferido();
         }else {
-            $('#button-send-resource').prop("disabled", true);
-            $("#divDeferido").hide();
+            hideIfDefault();
         }
     });
 
@@ -153,13 +150,38 @@ function inforesourceReply(resourceId) {
                 //$( "#resource_status option:selected" ).text('--Selecione--');
                 $('#resource_status option[value=Aguardando]').attr('selected','selected');
             }else{
+                if(response.resourceStatus == 'Deferido' || response.resourceStatus == 'ParcialmenteDeferido'){
+                    hideIfDeferido();
+                }else if(response.resourceStatus == 'Indeferido'){
+                    hideIfIndeferido();
+                }else{
+                    hideIfDefault();
+                }
                 $('#resource_status option[value='+response.resourceStatus+']').attr('selected','selected');
+                console.log();
                 // $( "#resource_status option:selected" ).text(response.resourceStatus);
             }
             
         }
     );
 }
+function hideIfDeferido(){
+    $("#indeferido_reply").hide();
+    $("#divDeferido").show();
+    $("#resource_reply").show();
+}
+
+function hideIfIndeferido(){
+    $("#divDeferido").hide();
+    $("#resource_reply").show();
+}
+
+function hideIfDefault(){
+    $('#button-send-resource').prop("disabled", true);
+    $("#divDeferido").hide();
+    $("#resource_reply").hide();
+}
+
 // para mudar a cor da class na tr > td
 function infoColorStatus(status) {
     var classStatus = '';

--- a/conf-base.php
+++ b/conf-base.php
@@ -11,8 +11,8 @@ return [
     'maps.center' => [-5.058114374355702, -39.4134521484375],
     'maps.zoom.default' => 8,
 
-    'auth.provider' => 'Fake',
-    //'auth.provider' => 'OpauthKeyCloak',
+    //'auth.provider' => 'Fake',
+    'auth.provider' => 'OpauthKeyCloak',
     'auth.config' => [
         'logout_url'            => env('LOGOUT_URL', ''),
         'client_id'             => env('CLIENT_ID', ''),

--- a/conf-base.php
+++ b/conf-base.php
@@ -11,8 +11,8 @@ return [
     'maps.center' => [-5.058114374355702, -39.4134521484375],
     'maps.zoom.default' => 8,
 
-    // 'auth.provider' => 'Fake',
-    'auth.provider' => 'OpauthKeyCloak',
+    'auth.provider' => 'Fake',
+    //'auth.provider' => 'OpauthKeyCloak',
     'auth.config' => [
         'logout_url'            => env('LOGOUT_URL', ''),
         'client_id'             => env('CLIENT_ID', ''),

--- a/db-updates.php
+++ b/db-updates.php
@@ -542,6 +542,11 @@ return array(
     'create sequence category_meta' => function () use($conn) {
         $conn->executeQuery("CREATE SEQUENCE category_meta_id_seq INCREMENT BY 1 MINVALUE 1 START 1;");
     },
+
+    //NOVO CAMPO DA TABELA RECURSO PARA SITUACAO DO CANDIDATO
+    'add decisao_recurso' => function () use($conn) {
+        $conn->executeQuery("ALTER TABLE public.resources ADD decisao_recurso INT");
+    },
 );
 
 

--- a/layouts/parts/modals/form-reply-resource.php
+++ b/layouts/parts/modals/form-reply-resource.php
@@ -81,7 +81,7 @@
         <button data-remodal-action="cancel" class="btn btn-default" title="Sair da resposta">
             <i class="fa fa-close" aria-hidden="true"></i> Fechar
         </button>
-        <button class="btn btn-primary" disabled id="button-send-resource" type="submit" title="Enviar o seu recurso para essa oportunidade" style="margin-left: 20px;">
+        <button class="btn btn-primary" id="button-send-resource" type="submit" title="Enviar o seu recurso para essa oportunidade" style="margin-left: 20px;">
             <i class="fa fa-paper-plane" aria-hidden="true"></i> Responder
         </button>
     </form>

--- a/layouts/parts/modals/form-reply-resource.php
+++ b/layouts/parts/modals/form-reply-resource.php
@@ -5,6 +5,7 @@
 ?>
 
 <div class="remodal" data-remodal-id="modal-resposta-recurso">
+
     <button data-remodal-action="close" class="remodal-close"></button>
     <h1>Responder recurso</h1>
     <!-- Utlização do nome da oportunidade dentro do modal. --> 
@@ -12,7 +13,9 @@
     <!-- Utlização da informação enviada pelo usuário para contestação. --> 
     <p><small id="resourceText"></small></p>
     <!-- Formulario para envio da atualização da contestação do recurso. --> 
+    
     <form id="formReplyResource">
+
         <input type="hidden" name="_METHOD" value="PUT"/>
         <input type="hidden" name="resource_id" id="resource_id">
         <input type="hidden" name="evaluationMethod" id="evaluationMethod" value="<?php echo $type; ?>">
@@ -41,10 +44,12 @@
                             <?php 
                             }
                         ?>
+                    </tr>
                 </thead>
             </table>
         </div>
-        <div id="divDeferido">
+
+        <div id="divDeferido" style="display: none">
             <div class="alert info" style="text-align:center"> 
                 <?php 
                     if($type == 'technical'){ ?>
@@ -69,14 +74,14 @@
                 <option value="1">Alterar para selecionado</option>
                 <option value="2">Manter Status</option>
             </select>
+            <textarea placeholder="Resposta para a contestação do recurso: " name="resource_reply" id="resource_reply" cols="30" rows="20" class="form-control" style="height: 222px !important"></textarea>
         </div>
-        <textarea placeholder="Resposta para a contestação do recurso: " name="resource_reply" id="resource_reply" cols="30" rows="20" class="form-control" style="height: 222px !important"></textarea>
         </hr>
         <br>
         <button data-remodal-action="cancel" class="btn btn-default" title="Sair da resposta">
             <i class="fa fa-close" aria-hidden="true"></i> Fechar
         </button>
-        <button class="btn btn-primary" type="submit" title="Enviar o seu recurso para essa oportunidade" style="margin-left: 20px;">
+        <button class="btn btn-primary" disabled id="button-send-resource" type="submit" title="Enviar o seu recurso para essa oportunidade" style="margin-left: 20px;">
             <i class="fa fa-paper-plane" aria-hidden="true"></i> Responder
         </button>
     </form>

--- a/layouts/parts/modals/form-reply-resource.php
+++ b/layouts/parts/modals/form-reply-resource.php
@@ -6,7 +6,7 @@
 
 <div class="remodal" data-remodal-id="modal-resposta-recurso">
     <button data-remodal-action="close" class="remodal-close"></button>
-    <h1>Atualização do recurso.</h1>
+    <h1>Responder recurso</h1>
     <!-- Utlização do nome da oportunidade dentro do modal. --> 
     <p><strong>Oportunidade: <label id="replyOpportunityNameLabel"></label></strong></p>
     <!-- Utlização da informação enviada pelo usuário para contestação. --> 
@@ -34,9 +34,10 @@
                         </td>
                         <?php 
                             if($type == 'technical'){ ?>
-                                <td>
-                                    <label for="consolidated_result">Nota Resultado Final</label>
-                                </td>
+                        <td>
+                            <label for="">Nota Resultado Final</label>
+                            <input type="text" name="consolidated_result" id="consolidated_result" disabled class="form-control" style="background: #eaeaea;" >
+                        </td>
                             <?php 
                             }
                         ?>
@@ -65,7 +66,7 @@
            <label for="candidate_status">Status do Candidato</label>
             <select name="status" id="candidate_status" class="form-control">
                 <option value="0">--Selecione--</option>
-                <option value="1">Habilitar próxima fase (Alterar para selecionado)</option>
+                <option value="1">Alterar para selecionado</option>
                 <option value="2">Manter Status</option>
             </select>
         </div>

--- a/layouts/parts/modals/form-reply-resource.php
+++ b/layouts/parts/modals/form-reply-resource.php
@@ -8,7 +8,7 @@
     <button data-remodal-action="close" class="remodal-close"></button>
     <h1>Responder recurso</h1>
     <!-- Utlização do nome da oportunidade dentro do modal. --> 
-    <p><strong>Oportunidade: <label id="replyOpportunityNameLabel"></label></strong></p>
+    <p><label id="replyOpportunityNameLabel"></label></strong></p>
     <!-- Utlização da informação enviada pelo usuário para contestação. --> 
     <p><small id="resourceText"></small></p>
     <!-- Formulario para envio da atualização da contestação do recurso. --> 

--- a/layouts/parts/modals/form-reply-resource.php
+++ b/layouts/parts/modals/form-reply-resource.php
@@ -45,7 +45,7 @@
             <div class="alert info" style="text-align:center"> 
                 <?php 
                     if($type == 'technical'){ ?>
-                        <label infoNotaMaxima></label>
+                        <label infoNotaMaxima>Atenção! Avalie o Recurso e Preencha os Campos Necessários</label>
                     <?php
                     }else{ ?>
                         <label>Preencha todos os campos abaixo: </label>

--- a/layouts/parts/modals/form-reply-resource.php
+++ b/layouts/parts/modals/form-reply-resource.php
@@ -22,11 +22,13 @@
                 <thead>
                     <tr>
                         <td>
-                            <label for="resource_status">Situação: </label>
+                            <label for="resource_status">Situação do recurso: </label>
                             <select name="resource_status" id="resource_status" class="form-control">
                                 <option value="default">--Selecione--</option>
                                 <option value="Deferido">Deferido</option>
+                                <?php  if($type == 'technical'): ?>
                                 <option value="ParcialmenteDeferido">Parcialmente Deferido</option>
+                                <?php endif; ?>
                                 <option value="Indeferido">Indeferido</option>
                             </select>
                         </td>
@@ -63,7 +65,7 @@
            <label for="candidate_status">Status do Candidato</label>
             <select name="status" id="candidate_status" class="form-control">
                 <option value="0">--Selecione--</option>
-                <option value="1">Habilitar próxima fase</option>
+                <option value="1">Habilitar próxima fase (Alterar para selecionado)</option>
                 <option value="2">Manter Status</option>
             </select>
         </div>

--- a/layouts/parts/modals/form-reply-resource.php
+++ b/layouts/parts/modals/form-reply-resource.php
@@ -68,8 +68,8 @@
                 <?php
                 }
             ?>
-           <label for="candidate_status">Status do Candidato</label>
-            <select name="status" id="candidate_status" class="form-control">
+           <label for="decisao_recurso">Status do Candidato</label>
+            <select name="status" id="decisao_recurso" class="form-control">
                 <option value="0">--Selecione--</option>
                 <option value="1">Alterar para selecionado</option>
                 <option value="2">Manter Status</option>

--- a/layouts/parts/modals/form-reply-resource.php
+++ b/layouts/parts/modals/form-reply-resource.php
@@ -74,8 +74,8 @@
                 <option value="1">Alterar para selecionado</option>
                 <option value="2">Manter Status</option>
             </select>
-            <textarea placeholder="Resposta para a contestação do recurso: " name="resource_reply" id="resource_reply" cols="30" rows="20" class="form-control" style="height: 222px !important"></textarea>
         </div>
+        <textarea placeholder="Resposta para a contestação do recurso: " name="resource_reply" id="resource_reply" cols="30" rows="20" class="form-control" style="height: 222px !important; display: none;"></textarea>
         </hr>
         <br>
         <button data-remodal-action="cancel" class="btn btn-default" title="Sair da resposta">

--- a/layouts/parts/modals/form-reply-resource.php
+++ b/layouts/parts/modals/form-reply-resource.php
@@ -1,69 +1,80 @@
+<?php
+    use MapasCulturais\i;
+    $entities = $this->controller->requestedEntity;
+    $type =  $entities->evaluationMethodConfiguration->getDefinition()->slug;
+?>
+
 <div class="remodal" data-remodal-id="modal-resposta-recurso">
     <button data-remodal-action="close" class="remodal-close"></button>
-    <h1>Responder Recurso</h1>
-    <p>
-        <strong>Oportunidade: 
-        <label id="replyOpportunityNameLabel"></label>
-        </strong>
-    </p>
-    <p>
-        <small id="resourceText"></small>
-    </p>
+    <h1>Atualização do recurso.</h1>
+    <!-- Utlização do nome da oportunidade dentro do modal. --> 
+    <p><strong>Oportunidade: <label id="replyOpportunityNameLabel"></label></strong></p>
+    <!-- Utlização da informação enviada pelo usuário para contestação. --> 
+    <p><small id="resourceText"></small></p>
+    <!-- Formulario para envio da atualização da contestação do recurso. --> 
     <form id="formReplyResource">
-        <textarea name="resource_reply" id="resource_reply" cols="30" rows="20" class="form-control" style="height: 222px !important"></textarea>
-        <br>
+        <input type="hidden" name="_METHOD" value="PUT"/>
+        <input type="hidden" name="resource_id" id="resource_id">
+        <input type="hidden" name="evaluationMethod" id="evaluationMethod" value="<?php echo $type; ?>">
+        
         <div class="table-responsive">
             <table class="table">
                 <thead>
                     <tr>
                         <td>
-                            <label for="">Situação</label>
+                            <label for="resource_status">Situação: </label>
                             <select name="resource_status" id="resource_status" class="form-control">
-                                <option value="">--Selecione--</option>
+                                <option value="default">--Selecione--</option>
                                 <option value="Deferido">Deferido</option>
                                 <option value="ParcialmenteDeferido">Parcialmente Deferido</option>
                                 <option value="Indeferido">Indeferido</option>
                             </select>
                         </td>
-                        <td>
-                            <label for="">Nota Resultado Final</label>
-                            <input type="text" name="consolidated_result" id="consolidated_result" disabled class="form-control" style="background: #eaeaea;" >
-                        </td>
-                        <td>
-                            
-                        </td>
-                    </tr>
+                        <?php 
+                            if($type == 'technical'){ ?>
+                                <td>
+                                    <label for="consolidated_result">Nota Resultado Final</label>
+                                </td>
+                            <?php 
+                            }
+                        ?>
                 </thead>
             </table>
         </div>
-        <br>
-        <div id="divDeferido" style="display: inline-table !important;">
-            <div class="alert info">
-                <label id="infoNotaMaxima"></label>
+        <div id="divDeferido">
+            <div class="alert info" style="text-align:center"> 
+                <?php 
+                    if($type == 'technical'){ ?>
+                        <label infoNotaMaxima></label>
+                    <?php
+                    }else{ ?>
+                        <label>Preencha todos os campos abaixo: </label>
+                    <?php
+                    }
+                ?>
             </div>
-            <label for="">Nova nota</label>
-            <input type="number" 
-            min="0"
-            step=".01"
-            name="new_consolidated_result" id="new_consolidated_result"
-            class="form-control">
-            <label for="">Status do Candidato</label>
-            <select name="status" id="" class="form-control">
+            <?php 
+                if($type == 'technical'){ ?>
+                    <label for="">Nova nota</label>
+                    <input type="number"  min="0" step=".01" name="new_consolidated_result" id="new_consolidated_result" class="form-control">
+                <?php
+                }
+            ?>
+           <label for="candidate_status">Status do Candidato</label>
+            <select name="status" id="candidate_status" class="form-control">
                 <option value="0">--Selecione--</option>
                 <option value="1">Habilitar próxima fase</option>
                 <option value="2">Manter Status</option>
             </select>
         </div>
-        <hr>
+        <textarea placeholder="Resposta para a contestação do recurso: " name="resource_reply" id="resource_reply" cols="30" rows="20" class="form-control" style="height: 222px !important"></textarea>
+        </hr>
+        <br>
         <button data-remodal-action="cancel" class="btn btn-default" title="Sair da resposta">
-        <i class="fa fa-close" aria-hidden="true"></i>
-        Fechar
+            <i class="fa fa-close" aria-hidden="true"></i> Fechar
         </button>
-        <input type="hidden" name="_METHOD" value="PUT"/>
-        <input type="hidden" name="resource_id" id="resource_id">
         <button class="btn btn-primary" type="submit" title="Enviar o seu recurso para essa oportunidade" style="margin-left: 20px;">
-        <i class="fa fa-paper-plane" aria-hidden="true"></i>
-        Responder
+            <i class="fa fa-paper-plane" aria-hidden="true"></i> Responder
         </button>
     </form>
 </div>

--- a/layouts/parts/modals/form-resource.php
+++ b/layouts/parts/modals/form-resource.php
@@ -3,7 +3,6 @@
     <h1>Formulário de recurso</h1>
     <p>
         <label id="opportunityNameLabel"></label>
-        </strong>
     </p>
     <form id="formSendResource">
         <textarea name="resource_text" id="" cols="30" rows="20" class="form-control" style="height: 322px !important"></textarea>

--- a/layouts/parts/modals/form-resource.php
+++ b/layouts/parts/modals/form-resource.php
@@ -2,7 +2,6 @@
     <button data-remodal-action="close" class="remodal-close"></button>
     <h1>Formulário de recurso</h1>
     <p>
-        <strong>Oportunidade: 
         <label id="opportunityNameLabel"></label>
         </strong>
     </p>

--- a/layouts/parts/panel-registration.php
+++ b/layouts/parts/panel-registration.php
@@ -76,17 +76,19 @@ $rec = Resources::getEnabledResource($registration->opportunity->id, 'period');
         <?php
         //VERIFICA SE ENVIOU O RECURSO
         if ($resources == false) {
-            if ($rec['open'] == 1 && $rec['close'] == 1) { ?>
+            if ($rec['open'] == true && $rec['close'] == false) { ?>
                 <a data-remodal-target="modal-recurso" onclick="showModalResource('<?php echo $registration->id; ?>', '<?php echo $registration->opportunity->id; ?>', '<?php echo $registration->owner->id; ?>', '<?php echo $registration->opportunity->name; ?>')" class="btn btn-primary">
                     <i class="fa fa-edit"></i> Abrir Recurso
                 </a>
+
+                
         <?php
             }
         } else {
             echo '<label class="text-info">Recurso enviado</label><br/>';
         }
         //MENSAGEM FORA DO PERIODO
-        if ($rec['open'] != 1 || $rec['close'] != 1) {
+        if ($rec['open'] == false || $rec['close'] == true) {
             echo '<label class="text-danger">Fora do período do recurso</label><br/>';
         }
 

--- a/layouts/parts/panel-registration.php
+++ b/layouts/parts/panel-registration.php
@@ -76,24 +76,23 @@ $rec = Resources::getEnabledResource($registration->opportunity->id, 'period');
         <?php
         //VERIFICA SE ENVIOU O RECURSO
         if ($resources == false) {
-            if ($rec['open'] == true && $rec['close'] == false) { ?>
+            if ($rec['open'] == true && $rec['close'] == true) { ?>
                 <a data-remodal-target="modal-recurso" onclick="showModalResource('<?php echo $registration->id; ?>', '<?php echo $registration->opportunity->id; ?>', '<?php echo $registration->owner->id; ?>', '<?php echo $registration->opportunity->name; ?>')" class="btn btn-primary">
                     <i class="fa fa-edit"></i> Abrir Recurso
                 </a>
-
-                
         <?php
             }
         } else {
             echo '<label class="text-info">Recurso enviado</label><br/>';
         }
         //MENSAGEM FORA DO PERIODO
-        if ($rec['open'] == false || $rec['close'] == true) {
+        if ($rec['open'] != true || $rec['close'] != true) {
             echo '<label class="text-danger">Fora do período do recurso</label><br/>';
         }
 
         ?>
     <?php endif; ?>
+
     <div class="objeto-meta">
         <div><span class="label" <?php \MapasCulturais\i::esc_attr_e("Responsável:"); ?>></span> <?php echo $registration->owner->name ?></div>
         <?php

--- a/layouts/parts/singles/opportunity-resources--form.php
+++ b/layouts/parts/singles/opportunity-resources--form.php
@@ -50,7 +50,7 @@
                 </div>
                 <div class="">
                     <label for="hora-inicial">Hora de início </label>
-                    <input type="text" class="time form-control" name="hour-initial" value="<?php echo $period['horIni']; ?>">
+                    <input type="time" class="form-control" name="hour-initial" value="<?php echo $period['horIni']; ?>">
                 </div>
                 <div class="form-group">
                     <label for="data-final">Data final </label>
@@ -58,7 +58,7 @@
                 </div>
                 <div class="form-group">
                     <label for="hora-final">Hora final </label>
-                    <input type="text" class="time form-control" name="hour-final" value="<?php echo $period['horFim']; ?>">
+                    <input type="time" class="form-control" name="hour-final" value="<?php echo $period['horFim']; ?>">
                 </div>
                 <div class="form-group">
                     <input type="hidden" name="opportunity" id="opportunityIdResources">

--- a/layouts/parts/singles/opportunity-resources.php
+++ b/layouts/parts/singles/opportunity-resources.php
@@ -34,7 +34,7 @@ $resources = Resources::resourceIdOpportunity($entity->id);
             <tr>
                 <th><?php echo $rec->registrationId->number; ?></th>
                 <th><?php echo $rec->agentId->name; ?></th>
-                <th><?php echo  $rec->resourceSend->format('d/m/Y H:i:s'); ?></th>
+                <th><?php echo $rec->resourceSend->format('d/m/Y H:i:s'); ?></th>
                 <th>
                     <?php 
                         ($resources[$key]['reply_agent_id'] !== NULL && $resources[$key]['reply_agent_id'] > 0) ? printf($agentReply->name) : $agentReply;
@@ -55,7 +55,14 @@ $resources = Resources::resourceIdOpportunity($entity->id);
                         echo 'Recurso já foi publicado';
                     } ?>
                 </th>
-                <th><?php echo  $rec->resourceDateReply->format('d/m/Y H:i:s'); ?></th>
+                <th><?php if ($rec->resourceDateReply !== null){ 
+                    echo $rec->resourceDateReply->format('d/m/Y H:i:s'); 
+                    
+                }
+                else{
+                    echo 'Aguardando';
+                }
+                ?></th>
             </tr>
         <?php } ?>
         </tbody>

--- a/layouts/parts/singles/opportunity-resources.php
+++ b/layouts/parts/singles/opportunity-resources.php
@@ -11,9 +11,11 @@ $resources = Resources::resourceIdOpportunity($entity->id);
                 <!-- <th>Publicar</th> -->
                 <th>Inscrição</th>
                 <th>Agente</th>
+                <th>Enviado em: </th> 
+                <th>Responsável</th>
                 <th>Status</th>
                 <th>Responder</th>
-                <th>Responsável</th>
+                <th>Respondido em: </th>
             </tr>
         </thead>
         <tbody>
@@ -32,6 +34,12 @@ $resources = Resources::resourceIdOpportunity($entity->id);
             <tr>
                 <th><?php echo $rec->registrationId->number; ?></th>
                 <th><?php echo $rec->agentId->name; ?></th>
+                <th><?php echo  $rec->resourceSend->format('d/m/Y H:i:s'); ?></th>
+                <th>
+                    <?php 
+                        ($resources[$key]['reply_agent_id'] !== NULL && $resources[$key]['reply_agent_id'] > 0) ? printf($agentReply->name) : $agentReply;
+                    ?>
+                </th>
                 <th><?php echo $rec->resourceStatus; ?></th>
                 <th>
                     <?php  
@@ -47,11 +55,7 @@ $resources = Resources::resourceIdOpportunity($entity->id);
                         echo 'Recurso já foi publicado';
                     } ?>
                 </th>
-                <th>
-                    <?php 
-                        ($resources[$key]['reply_agent_id'] !== NULL && $resources[$key]['reply_agent_id'] > 0) ? printf($agentReply->name) : $agentReply;
-                    ?>
-                </th>
+                <th><?php echo  $rec->resourceDateReply->format('d/m/Y H:i:s'); ?></th>
             </tr>
         <?php } ?>
         </tbody>

--- a/layouts/parts/singles/opportunity-resources.php
+++ b/layouts/parts/singles/opportunity-resources.php
@@ -40,7 +40,7 @@ $resources = Resources::resourceIdOpportunity($entity->id);
                         ($resources[$key]['reply_agent_id'] !== NULL && $resources[$key]['reply_agent_id'] > 0) ? printf($agentReply->name) : $agentReply;
                     ?>
                 </th>
-                <th><?php echo $rec->resourceStatus; ?></th>
+                <th><?php echo preg_replace('/(?<!\ )[A-Z]/', ' $0', $rec->resourceStatus);  ?></th>
                 <th>
                     <?php  
                        if(isset($resources[0]['resources_reply_publish']) && $resources[0]['resources_reply_publish'] == false) {

--- a/layouts/parts/singles/opportunity-resources.php
+++ b/layouts/parts/singles/opportunity-resources.php
@@ -47,7 +47,7 @@ $resources = Resources::resourceIdOpportunity($entity->id);
                         echo substr($rec->resourceReply, 0 , 30) ;
                     ?>...
                     <p>
-                    <a href="#modal-resposta-recurso" onclick="showModalReply('<?php echo $rec->id; ?>', '<?php echo $entity->id; ?>', '<?php echo $rec->opportunityId->name; ?>','<?php echo $registration->consolidatedResult; ?>')" class="btn btn-info" title="Responder o recurso do <?php echo $rec->agentId->name; ?>">
+                    <a href="#modal-resposta-recurso" onclick="showModalReply('<?php echo $rec->id; ?>', '<?php echo $entity->id; ?>', '<?php echo $rec->opportunityId->name; ?>','<?php echo $rec->decisao_recurso;?>','<?php echo $registration->consolidatedResult; ?>')" class="btn btn-info" title="Responder o recurso do <?php echo $rec->agentId->name; ?>">
                         <i class="fa fa-share-square" aria-hidden="true"></i> Responder Recurso
                     </a>
                     </p>


### PR DESCRIPTION
Responsáveis:  
@FernandaNascimento26 
@lucastandy 
@victorMagalhaesPacheco 
@pedrovitor074 

Linked Issue:  

#232 

### Descrição

Atualmente o módulo de recursos que foi implementado pela ESP, está funcionando para avaliações técnica, entretanto avaliações do tipo "simplificada" ou "documental" não estão com o ciclo completo de funcionalidades funcionando. 

Diante disso, essa issue resolveu este problema, adicionando verificação para que não haja o campo de notas em avaliações simplificadas e documentais conforme figma disponibilizado pela equipe de UX.

Outras alterações foram:

Em nosso tema as alterações foram:

- Remover os segundos do formulário de recursos; 
- Botão para abrir os recursos devem aparecer somente se estiver no período
- Outros dois bugs que apareceram somente em ambiente local:  no momento da avaliação técnica quando se selecionava um candidato para avaliar retornava página de erro e também no momento de responder o recurso da avaliação técnica. 

### 🖥 Passos a passo para teste

1. Criar oportunidade (simplificada e documental) e habilitar recurso (observar que no cadastro do periodo só consta hh:mm)
2. Inscrever candidato
3. Avaliar candidato
4. Logar como o candidato e solicitar recurso (atentar-se ao período de solicitação de recurso)
5. Logar como avaliador e respónder recurso
6. Verificar se o fluxo funciona bem, se consegue responder, publicar, deferir indeferir, alterar e manter status do candidato;
7. Observar se as modificações são aplicadas ao candidato (status e situação do recurso); 


## Checklist para criação do PR

- [ ] Testes foram implementados (novos ou não)
- [x] Issue foi definida no PR (Linked Issue na coluna à direita da página)
- [x] Pessoas contribuidoras foram definidas no PR (Assigners no PR)
