### PR TITLE
#238 atualizacao do texto de envio de anexo

### DIFF
--- a/layouts/parts/singles/registration-edit--fields.php
+++ b/layouts/parts/singles/registration-edit--fields.php
@@ -46,10 +46,9 @@
 
                     <form class="js-ajax-upload" method="post" action="{{uploadUrl}}" data-group="{{::field.groupName}}"  enctype="multipart/form-data">
                         <div class="alert danger hidden"></div>
-                        <p class="form-help" style="font-weight: bold;">Arquivos devem ser compactados em formato .zip</p>
-                        <p class="form-help"><?php \MapasCulturais\i::_e("Tamanho máximo do arquivo:");?> {{maxUploadSizeFormatted}}</p>
+                        <p>Selecione seu anexo:</p>
                         <input type="file" name="{{::field.groupName}}" />
-
+                        <p class="form-help">Consulte o edital desta oportunidade para entender as limitações de tamanho e formato dos arquivos solicitados.</p>
                         <div class="js-ajax-upload-progress">
                             <div class="progress">
                                 <div class="bar"></div>


### PR DESCRIPTION
Responsáveis:  
@FernandaNascimento26 

Linked Issue:  

#238 

### Descrição

Atualmente o Mapa da Saúde aceita documentos em diferentes formatos, mas a informação no campo de anexo sugere ao candidato inserir documentos compactados por meio de zip. 

Essa informação foi retirada, bem como a informação do tamanho máximo do arquivo. 

### 🖥 Passos a passo para teste

1. Criar uma oportunidade e configurá-la para que receba um campo do tipo anexo. 
2. Logar como agente e se inscrever na oportunidade criada. 
3. Verificar o campo de envio de anexo durante a realização da inscrição (verificar se as novas informações foram aplicadas). 

## Checklist para criação do PR

- [ ] Testes foram implementados (novos ou não)
- [x] Issue foi definida no PR (Linked Issue na coluna à direita da página)
- [x] Pessoas contribuidoras foram definidas no PR (Assigners no PR)
