### PR TITLE
#493 Adicionar campo do Lattes no perfil do agente

### DIFF
--- a/agent-types.php
+++ b/agent-types.php
@@ -147,8 +147,7 @@ return array(
 
         'curriculoLattes' => array(
             'label' => \MapasCulturais\i::__('Cole o link aqui'),
-            'type' => 'string',
-            'available_for_opportunities' => true,
+            'type' => 'string'
         ),
 
         'telefone1' => array(

--- a/agent-types.php
+++ b/agent-types.php
@@ -145,6 +145,12 @@ return array(
            // 'field_type' => 'brPhone'
         ),
 
+        'curriculoLattes' => array(
+            'label' => \MapasCulturais\i::__('Cole o link aqui'),
+            'type' => 'string',
+            'available_for_opportunities' => true,
+        ),
+
         'telefone1' => array(
             'private' => true,
             'label' => \MapasCulturais\i::__('Telefone 1'),

--- a/layouts/parts/singles/agent-form.php
+++ b/layouts/parts/singles/agent-form.php
@@ -6,9 +6,6 @@ $allPro = ProfessionalCategory::allProfessional();
 //RETORNA AS ESPECIALIDADES DO AGENTE
 $getSpecialty = ProfessionalCategory::getSpecialtyEntity($entity, 'profissionais_especialidades');
 
-//RETORNA O CURRÍCULO LATTES DO AGENTE
-$getCurriculoLattes = ProfessionalCategory::getSpecialtyEntity($entity, 'curriculoLattes');
-
 $upCategoryAndSpecialty = ProfessionalCategory::alterCategoryProfessional($entity->id);
 
 //RETORNA AS CATEGORIAS DO AGENTE
@@ -190,13 +187,19 @@ endif;
     <?php endif;?>
 </p>
 <p>
-    <!-- Currículo Lattes -->
+    <!-- Início do Trecho de Código Responsável por exibir o campo Currículo Lattes -->
     <span class="label"><?php \MapasCulturais\i::_e("Currículo Lattes");?>:</span>
-    <?php if (!empty($getCurriculoLattes)): ?>
-        <span class="">
-        <a style="color: #0000FF; text-decoration: underline; font-weight:normal;" target="_blank" href="<?php echo $getCurriculoLattes; ?>"><?php echo $getCurriculoLattes; ?></a>
-        </span>
+    <?php
+        $campo_curriculo_lattes = $entity->curriculoLattes;
+        if (!empty($campo_curriculo_lattes)):
+    ?>
+    <span class="">
+        <a style="color: #0000FF; text-decoration: underline; font-weight:normal;" target="_blank" href="<?php echo $entity->curriculoLattes; ?>"><?php echo $entity->curriculoLattes; ?></a>
+    </span>
+    <?php else:?>
+        <span class="">Não Informado</span>
     <?php endif;?>
+    <!-- Fim do Trecho de Código Responsável por exibir o campo Currículo Lattes -->
 </p>
 <?php endif;
 if ($this->controller->action === 'edit'): ?>

--- a/layouts/parts/singles/agent-form.php
+++ b/layouts/parts/singles/agent-form.php
@@ -6,6 +6,9 @@ $allPro = ProfessionalCategory::allProfessional();
 //RETORNA AS ESPECIALIDADES DO AGENTE
 $getSpecialty = ProfessionalCategory::getSpecialtyEntity($entity, 'profissionais_especialidades');
 
+//RETORNA O CURRÍCULO LATTES DO AGENTE
+$getCurriculoLattes = ProfessionalCategory::getSpecialtyEntity($entity, 'curriculoLattes');
+
 $upCategoryAndSpecialty = ProfessionalCategory::alterCategoryProfessional($entity->id);
 
 //RETORNA AS CATEGORIAS DO AGENTE
@@ -125,6 +128,12 @@ echo $dtN ? $dtN->format('d/m/Y') : '';?>
                     <?php echo $entity->telefone2; ?>
                 </span>
             </p>
+            <!-- Campo Lattes -->
+            <p><span class="label"><?php \MapasCulturais\i::_e("Currículo Lattes");?>:</span>
+                <span class="js-editable <?php echo ($entity->isPropertyRequired($entity, "curriculoLattes") && $this->isEditable() ? 'required' : ''); ?>" data-edit="curriculoLattes" data-original-title="<?php \MapasCulturais\i::esc_attr_e("Currículo Lattes");?>" data-emptytext="<?php \MapasCulturais\i::esc_attr_e("Adicione o link do currículo lattes");?>">
+                    <?php echo $entity->curriculoLattes; ?>
+                </span>
+            </p>
         <?php endif;?>
         <!-- <p>
             <span class="label"><?php \MapasCulturais\i::_e("Categoria profissional");?>:</span>
@@ -178,8 +187,16 @@ endif;
         <span class="">
             <?php echo $getSpecialty; ?>
         </span>
-    <?php endif;
-?>
+    <?php endif;?>
+</p>
+<p>
+    <!-- Currículo Lattes -->
+    <span class="label"><?php \MapasCulturais\i::_e("Currículo Lattes");?>:</span>
+    <?php if (!empty($getCurriculoLattes)): ?>
+        <span class="">
+        <a style="color: #0000FF; text-decoration: underline; font-weight:normal;" target="_blank" href="<?php echo $getCurriculoLattes; ?>"><?php echo $getCurriculoLattes; ?></a>
+        </span>
+    <?php endif;?>
 </p>
 <?php endif;
 if ($this->controller->action === 'edit'): ?>


### PR DESCRIPTION
Responsáveis:   
@lucastandy 
 
Linked Issue:   
 
#493 
 
### Objetivo
 
Como usuário/cliente do mapa
Quero completar meu perfil
Para ficar o mais completo possível
 
### Contexto
Inserir o campo do Lattes no perfil do agente para que no cadastro ou atualização do perfil ele possa informar seu lattes.

### Escopo
Atualizar campos do perfil do agente para constar o campo de inserir link do lattes

### Critérios de Aceitação
Campo para que o agente insira link do lattes em seu perfil do mapa

Dado que Acesso meu perfil de inscrição
Quando faço a inserção do link do meu lattes
então consta link do lattes no meu perfil
 
### 🖥 Passos a passo para teste 
 
1. Acessar a página Meu Perfil;
2. Clicar no botão "Editar", situado no canto superior direito da tela;
3. Localizar o campo "Currículo Lattes", abaixo do campo "Telefone 2";
4. Informe o link do currículo lattes e depois clique no botão "Salvar", localizado no canto superior direito da tela.
