### PR TITLE
#256 Apresentar a descrição em campos checkbox no formulário de inscrição

### DIFF
--- a/layouts/parts/singles/registration-single--fields.php
+++ b/layouts/parts/singles/registration-single--fields.php
@@ -9,8 +9,7 @@
             <div ng-if="field.fieldType !== 'file' && field.fieldType !== 'section' && field.fieldType !== 'persons' && field.config.entityField !== '@location' && field.config.entityField !== '@links' &&  field.fieldType !== 'links' ">
                 <label>{{field.required ? '*' : ''}} {{field.title}}: </label>
                 <span ng-if="entity[field.fieldName] && field.fieldType !== 'textarea'&& field.fieldType !== 'checkbox'" ng-bind-html="printField(field, entity[field.fieldName])"></span>
-                <span ng-if="entity[field.fieldName] && field.fieldType === 'checkbox'">{{field.description}}</span>
-                
+                <span ng-if="entity[field.fieldName] && field.fieldType === 'checkbox'">{{field.description}}<span>
                 <p ng-if="entity[field.fieldName] && field.fieldType === 'textarea'" ng-bind-html="printField(field, entity[field.fieldName])" style="white-space: pre-line"></p>
                 <span ng-if="!entity[field.fieldName]"><em><?php \MapasCulturais\i::_e("Campo não informado.");?></em></span>
             </div>

--- a/layouts/parts/singles/registration-single--fields.php
+++ b/layouts/parts/singles/registration-single--fields.php
@@ -1,0 +1,47 @@
+<div ng-if="data.fields.length > 0" id="registration-attachments" class="registration-fieldset">
+    <!--
+    <h4><?php \MapasCulturais\i::_e("Campos adicionais do formulário de inscrição.");?></h4>
+    -->
+    
+    <ul class="attachment-list" ng-controller="RegistrationFieldsController">
+
+        <li ng-repeat="field in data.fields" ng-if="showField(field)" id="field_{{::field.id}}" data-field-id="{{::field.id}}" ng-class=" (field.fieldType != 'section') ? 'js-field attachment-list-item registration-view-mode' : ''">
+            <div ng-if="field.fieldType !== 'file' && field.fieldType !== 'section' && field.fieldType !== 'persons' && field.config.entityField !== '@location' && field.config.entityField !== '@links' &&  field.fieldType !== 'links' ">
+                <label>{{field.required ? '*' : ''}} {{field.title}}: </label>
+                <span ng-if="entity[field.fieldName] && field.fieldType !== 'textarea'&& field.fieldType !== 'checkbox'" ng-bind-html="printField(field, entity[field.fieldName])"></span>
+                <span ng-if="entity[field.fieldName] && field.fieldType === 'checkbox'">{{field.description}}</span>
+                
+                <p ng-if="entity[field.fieldName] && field.fieldType === 'textarea'" ng-bind-html="printField(field, entity[field.fieldName])" style="white-space: pre-line"></p>
+                <span ng-if="!entity[field.fieldName]"><em><?php \MapasCulturais\i::_e("Campo não informado.");?></em></span>
+            </div>
+            <div ng-if="field.fieldType === 'section'">
+                <h4>{{field.title}}</h4>
+            </div>
+            <div ng-if="field.fieldType === 'persons'">
+                <label>{{field.required ? '*' : ''}} {{field.title}}: </label> 
+                <div ng-repeat="(key, item) in entity[field.fieldName]" ng-if="item && key !== 'location' && key !== 'publicLocation' " >
+                    <div><b ng-if="item.name">Nome: </b>{{item.name}}<b ng-if="item.cpf"> CPF: </b>{{item.cpf}} <b ng-if="item.relationship">Relação: </b>{{item.relationship}}</div>
+                </div>
+            </div>
+            <?php //@TODO pegar endereço do campo endereço (verificar porque não esta salvando corretamente, arquicos location.js e _location.php)?>
+            <div ng-if="field.config.entityField === '@location'">
+                <label>{{field.required ? '*' : ''}} {{field.title}}: </label> 
+                <div ng-repeat="(key, item) in entity[field.fieldName]" ng-if="item && key !== 'location' && key !== 'publicLocation' " >
+                {{key.split('_').pop()}}: {{item}} 
+                </div>
+            </div>
+            <div ng-if="field.config.entityField === '@links' || field.fieldType === 'links'">
+                <label>{{field.required ? '*' : ''}} {{field.title}}: </label> 
+                <div ng-repeat="(key, item) in entity[field.fieldName]" ng-if="item && key !== 'location' && key !== 'publicLocation' " >
+                <b>{{item.title}}:</b> <a target="_blank" href="{{item.value}}">{{item.value}}</a>
+                </div>
+            </div>
+
+            <div ng-if="field.fieldType === 'file'">
+                <label>{{::field.required ? '*' : ''}} {{::field.title}}: </label>
+                <a ng-if="field.file" class="attachment-title" href="{{::field.file.url}}" target="_blank" rel='noopener noreferrer'>{{::field.file.name}}</a>
+                <span ng-if="!field.file"><em><?php \MapasCulturais\i::_e("Arquivo não enviado.");?></em></span>
+            </div>
+        </li>
+    </ul>
+</div>

--- a/layouts/parts/singles/registration-single--fields.php
+++ b/layouts/parts/singles/registration-single--fields.php
@@ -9,7 +9,7 @@
             <div ng-if="field.fieldType !== 'file' && field.fieldType !== 'section' && field.fieldType !== 'persons' && field.config.entityField !== '@location' && field.config.entityField !== '@links' &&  field.fieldType !== 'links' ">
                 <label>{{field.required ? '*' : ''}} {{field.title}}: </label>
                 <span ng-if="entity[field.fieldName] && field.fieldType !== 'textarea'&& field.fieldType !== 'checkbox'" ng-bind-html="printField(field, entity[field.fieldName])"></span>
-                <span ng-if="entity[field.fieldName] && field.fieldType === 'checkbox'">{{field.description}}<span>
+                <span ng-if="entity[field.fieldName] && field.fieldType === 'checkbox'">{{field.description}}</span>
                 <p ng-if="entity[field.fieldName] && field.fieldType === 'textarea'" ng-bind-html="printField(field, entity[field.fieldName])" style="white-space: pre-line"></p>
                 <span ng-if="!entity[field.fieldName]"><em><?php \MapasCulturais\i::_e("Campo não informado.");?></em></span>
             </div>


### PR DESCRIPTION
Responsáveis:  
@FernandaNascimento26 
 

Linked Issue:  

#256

### Descrição

Atualmente no formulário de inscrição de um candidato, os campos do tipo checkbox apresentam  o título do campo e "_true_", indicando que o candidato marcou aquela opção. Foi solicitado que ao invés do "_true_", seja apresentada a descrição do campo que geralmente é ultilizado para Declaração e/ou validação. 


### 🖥 Passos a passo para teste

1. Criar oportunidade e inserir um capo do tipo checkbox com nome e descrição
2. Inscrever candidato
3. Verificar como a informação é apresentada na ficha de inscrição


## Checklist para criação do PR

- [ ] Testes foram implementados (novos ou não)
- [x] Issue foi definida no PR (Linked Issue na coluna à direita da página)
- [x] Pessoas contribuidoras foram definidas no PR (Assigners no PR)
