### PR TITLE
#523 Melhoria no campo do e-mail de confirmação na inscrição de uma o…

### DIFF
--- a/Theme.php
+++ b/Theme.php
@@ -132,7 +132,9 @@ class Theme extends BaseV1\Theme{
          */
         $app->hook('view.partial(singles/opportunity-registrations--fields):after', function () {
             $entity = $this->controller->requestedEntity;
-            $this->part('singles/opportunity-field-mail-confirm.php', ['entity' => $entity]);
+            $mailTitleSendConfirmDefault = 'Confirmação de inscrição';
+            $mailDescriptionSendConfirmDefault = "Olá! Confirmamos sua inscrição no Mapa da Saúde.";
+            $this->part('singles/opportunity-field-mail-confirm.php', ['entity' => $entity, 'mailTitleSendConfirmDefault'=>$mailTitleSendConfirmDefault, 'mailDescriptionSendConfirmDefault'=>$mailDescriptionSendConfirmDefault]);
         });  
 
         /**
@@ -146,6 +148,7 @@ class Theme extends BaseV1\Theme{
 
                 $dataValue = [
                     'mailDescriptionSendConfirm' => $registration->opportunity->mailDescriptionSendConfirm,
+                    'name' => $registration->owner->name,
                     'number' => $registration->number,
                     'opportunity' => $registration->opportunity->name
                 ];

--- a/layouts/parts/singles/opportunity-field-mail-confirm.php
+++ b/layouts/parts/singles/opportunity-field-mail-confirm.php
@@ -8,17 +8,23 @@
       data-type="text"
       data-original-title="Informe o título de confirmação de inscrição" 
       data-emptytext="Informe o título de confirmação de inscrição">
-      <?=htmlspecialchars($entity->mailTitleSendConfirm)?>
+      <?php
+         $mailTitleFilled = $entity->mailTitleSendConfirm;
+         echo !empty($mailTitleFilled) ? htmlspecialchars($entity->mailTitleSendConfirm) : $mailTitleSendConfirmDefault;
+      ?>
    </span>
 </label> <br><br>
 
 <label> <b>Mensagem do e-mail</b> <br>
-   <span style="width: 100%;" class="js-editable" 
+   <span style="width: 100%; white-space: initial;" class="js-editable" 
       data-edit="mailDescriptionSendConfirm"
       data-type="textarea"
       data-original-title="Informe a mensagem de confirmação de inscrição" 
       data-emptytext="Informe a mensagem de confirmação de inscrição">
-      <?=htmlspecialchars($entity->mailDescriptionSendConfirm)?>
+      <?php
+         $mailDescriptionFilled = $entity->mailDescriptionSendConfirm;
+         echo !empty($mailDescriptionFilled) ? htmlspecialchars($entity->mailDescriptionSendConfirm) : $mailDescriptionSendConfirmDefault;
+      ?>
    </span>
 </label> <br><br>
 </div>

--- a/templates/pt_BR/registration_confirm_custom.html
+++ b/templates/pt_BR/registration_confirm_custom.html
@@ -2,6 +2,7 @@
     {{{mailDescriptionSendConfirm}}}<br>
     <p>
         Informações sobre a inscrição:<br><br>
+        Nome do Candidato: <b>{{name}}</b><br>
         Número de inscrição: <b>#{{number}}</b><br>
         Oportunidade: <b>{{opportunity}}</b><br>
     </p>


### PR DESCRIPTION
Melhoria no campo do e-mail de confirmação na inscrição de uma oportunidade
Issue #523

Responsáveis:   
@lucastandy @victorMagalhaesPacheco (apoio)

## **Objetivo**

**Como** administrador de uma oportunidade
**Quero** criar o texto que a pessoa receberá ao se inscrever em minha oportunidade ou utilizar modelo padrão
**Para** que seja personalizada de acordo com a oportunidade

## **Contexto**
O criador da oportunidade atualmente não pode escolher o texto que o inscrito receberá para confirmação de sua inscrição. A ideia é que seja algo personalizável de acordo com a oportunidade.
-

## **Critérios de Aceitação**

- [x] Disponibilização de texto padrão para que o criador da oportunidade possa utilizar ou não (pré-carregado na página)
**Dado que** crio uma oportunidade
**Quando** quero que os inscritos recebam e-mail para inscrição
**então** posso usar o texto básico disponibilizado pela plataforma