### PR TITLE
fix: problema com as oportunidades não estarem sendo agrupadas com mu…

### DIFF
--- a/views/panel/registrations.php
+++ b/views/panel/registrations.php
@@ -6,7 +6,12 @@ error_reporting(E_ALL);
     
     $drafts = $app->repo('Registration')->findByUser($app->user, Registration::STATUS_DRAFT);
     $sent = $app->repo('Registration')->findByUser($app->user, 'sent');
-    
+    $unique_opportunities = [];
+    foreach($sent as $s){
+        if(!array_key_exists($s->opportunity->ownerEntity->id , $unique_opportunities)){
+            $unique_opportunities[$s->opportunity->ownerEntity->id] = $s;
+        }
+    }
  ?>
 
 <div class="panel-list panel-main-content">
@@ -35,7 +40,7 @@ error_reporting(E_ALL);
     </div>
     <!-- #ativos-->
     <div id="enviadas">
-        <?php foreach($sent as $registration): ?>
+        <?php foreach($unique_opportunities as $registration): ?>
         <?php $this->part('panel-registration', array('registration' => $registration)); ?>
         <?php endforeach; ?>
         <?php if(!$sent): ?>


### PR DESCRIPTION
Responsáveis:
@pedrovitor074

Linked Issue:

#232 

Descrição
Foi verificado alguns problemas onde as provas de multiplas fases não estavam sendo agrupado

🖥 Passos a passo para teste
Acessar no menu superior Minhas inscrições e clicar em uma oportunidade que possua múltiplas fases.

Checklist para criação do PR
 Testes foram implementados (novos ou não)
 Issue foi definida no PR (Linked Issue na coluna à direita da página)
 Pessoas contribuidoras foram definidas no PR (Assigners no PR)