### PR TITLE
#283 multiplas inscrições config oportunidades

### DIFF
--- a/assets/js/ng.entity.module.opportunity.js
+++ b/assets/js/ng.entity.module.opportunity.js
@@ -2168,33 +2168,16 @@ module.controller('OpportunityController', ['$scope', '$rootScope', '$location',
 
     $scope.register = function(idOpportunity){
         var registration = $scope.data.registration;
-        var ownerRegistration = [];
-        /**
-         * idOpportunity = id da oportunidade
-         * Atualizado para passar o id de uma determinada oportunidade, pois anteriormente estava recebendo o id da oportunidade da entidade.
-         */
-        // @TODO: buscar na api
-        for(var i in $scope.data.registrations) {
-            if(registration.owner && $scope.data.registrations[i].owner){
-                if($scope.data.registrations[i].owner.id == registration.owner.id) {
-                    ownerRegistration.push($scope.data.registrations[i].owner);
+
+        RegistrationService.register(registration, idOpportunity).success(function(rs){
+            if (typeof rs.error !== 'undefined') {
+                if (rs.data.owner) {
+                    MapasCulturais.Messages.error(rs.data.owner);
                 }
-            }
-        }
-        if(MapasCulturais.entity.object.registrationLimitPerOwner > 0 && ownerRegistration.length >= MapasCulturais.entity.object.registrationLimitPerOwner) {
-            MapasCulturais.Messages.error(labels['limitReached']);
-        }else if(MapasCulturais.entity.object.registrationLimit > 0 && registration.owner && $scope.data.registrations.length >= MapasCulturais.entity.object.registrationLimit){
-            MapasCulturais.Messages.error(labels['VacanciesOver']);
-        }else if(registration.owner && (MapasCulturais.entity.object.registrationLimit == 0 || $scope.data.registrations.length <= MapasCulturais.entity.object.registrationLimit)){
-            RegistrationService.register(registration, idOpportunity).success(function(rs){
+            } else {
                 document.location = rs.editUrl;
-            });
-        }else {
-            setTimeout(function(){
-                $('#select-registration-owner-button').trigger("click");
-            }, 0);
-            MapasCulturais.Messages.error(labels['needResponsible']);
-        }
+            }
+        });
     };
 
     $scope.sendRegistrationRulesFile = function(){

--- a/layouts/parts/singles/opportunity-registrations--form.php
+++ b/layouts/parts/singles/opportunity-registrations--form.php
@@ -18,14 +18,10 @@ if (strpos($url_atual, 'opportunity') !== false) {
 	$btnHideShow = false;
 }
 
-$registrations = $app->repo('Registration')->findByOpportunityAndUser($entity, $app->user);
-
 if ($entity->isRegistrationOpen()): ?>
     <?php if ($app->auth->isUserAuthenticated()): ?>
-
        <!-- // SE O USUARIO TIVER PERMISSÃO PARA MODIFICAR A ENTIDADE -->
         <?php if (!($entity->canUser('modify')) && empty($userRelation)) : ?>
-            <?php if (empty($registrations)): ?>
             <form class="registration-form clearfix">
                 <p class="registration-help white-top" style="font-size: 14px;"><?php \MapasCulturais\i::_e("Para iniciar sua inscrição, selecione o agente responsável. Ele deve ser um agente individual (pessoa física), com um CPF válido preenchido.");?></p>
                 <div class="registration-form-content">
@@ -47,7 +43,6 @@ if ($entity->isRegistrationOpen()): ?>
                     </div>
                 </div>
             </form>
-            <?php endif; ?>
         <?php endif;?>
     <?php else: ?>
         <div class="alert danger" style="position: relative !important;">


### PR DESCRIPTION
Responsáveis: @victorMagalhaesPacheco 

Linked Issue: #283 

Descrição
Permitir N inscrições baseadas nas configurações da oportunidade.

🖥 Passos a passo para teste

1. Criar projjeto
2. Criar oportunidade
3. Especificar quantas inscrições possíveis por agente responsável
4. Realizar inscrições até chegar no limite previamente configurado
5. Ao chegar no limite previamente configurado na oportunidade, o sistema deve emitir uma mensagem de alerta informando o limite.

Checklist para criação do PR
- [ ] Testes foram implementados (novos ou não)
- [x] Issue foi definida no PR (Linked Issue na coluna à direita da página)
- [x] Pessoas contribuidoras foram definidas no PR (Assigners no PR)