### PR TITLE
Feature/update multiplos arquivos layout

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -7838,12 +7838,6 @@ nav {
     font-size: 1.3rem;
   }
 
-
-  .delete-attachment {
-    color: #f00 !important;
-    margin-right: 10px;
-  }
-
-  .delete-attachment:hover {
-    color: #fd5858 !important; 
+  .widget-list-item {
+    list-style-type: none !important;
   }

--- a/assets/js/ng.entity.module.opportunity.js
+++ b/assets/js/ng.entity.module.opportunity.js
@@ -1029,7 +1029,7 @@ module.controller('RegistrationFieldsController', ['$scope', '$rootScope', '$int
             $http.get(file.deleteUrl).success(function(response){
                 for (var key in $scope.data.fields) {
                     var field = $scope.data.fields[key];
-                    if (field.multiple && !field.file instanceof Array) {
+                    if (field.multiple && field.file instanceof Array) {
                         for (var f in field.file) {
                             var fil = field.file[f];
                             if (file.id == fil.id) {

--- a/layouts/parts/singles/registration-edit--fields.php
+++ b/layouts/parts/singles/registration-edit--fields.php
@@ -34,16 +34,18 @@
                     <li class="widget-list-item is-editable">
                         <a href="{{field.file.url}}" target="_blank" rel='noopener noreferrer'><span>{{field.file.name}}</span></a>
                         <div class="botoes">
-                            <a hltip ng-click="removeFile(field.file)" class="delete delete-attachment hltip" title="<?php \MapasCulturais\i::esc_attr_e("Excluir arquivo");?>"></a>
+                            <a hltip ng-click="removeFile(field.file)" class="delete hltip" title="<?php \MapasCulturais\i::esc_attr_e("Excluir arquivo");?>"></a>
                         </div>
                     </li>
                 </ul>
 
-                <ul ng-if="field.multiple" class="widget-list js-downloads js-slimScroll">
-                    <li ng-repeat="file in field.file" id="{{file.id}}" class="widget-list-item is-editable">
-                        <a href="{{file.url}}" target="_blank" rel='noopener noreferrer'><span>{{file.description}} - {{file.name}}</span></a>
-                        <div class="botoes">
-                            <a hltip ng-click="removeFile(file)" class="delete delete-attachment hltip" title="<?php \MapasCulturais\i::esc_attr_e("Excluir arquivo");?>"></a>
+                <ul ng-if="field.multiple" ng-repeat="file in field.file track by $index" class="widget-list js-downloads js-slimScroll">
+                    <li id="{{file.id}}" class="widget-list-item is-editable">
+                        <div>
+                            <a href="{{file.url}}" target="_blank" rel='noopener noreferrer'><span>{{file.description}} - {{file.name}}</span></a>
+                            <div class="botoes">
+                                <a hltip ng-click="removeFile(file)" class="delete hltip" title="<?php \MapasCulturais\i::esc_attr_e("Excluir arquivo");?>"></a>
+                            </div>
                         </div>
                     </li>
                 </ul>


### PR DESCRIPTION
Responsáveis:  @victorMagalhaesPacheco 

Linked Issue:  [#593](https://github.com/EscolaDeSaudePublica/mapadasaude/issues/593)

### Descrição

Atualização ícone seguindo o padrão de upload do mapas e mudança de estrutura exclusão.

### Passos a passo para teste

1. Criar oportunidade
2. Criar campos de anexos e selecionar a opção "Aceitar múltiplos arquivos"
3. Realizar inscrição 
4. Anexar 1 ou N arquivos
5. Enviar inscrição
6. Como administrador baixar todos os arquivos com zip ou acessar inscrição e visualizar separadamente os arquivos anexados para cada campo de anexo

### Observações

Não se aplica

## Checklist para criação do PR

- [ ] Testes foram implementados (novos ou não)
- [x] Issue foi definida no PR (Linked Issue na coluna à direita da página)
- [x] Pessoas contribuidoras foram definidas no PR (Assigners no PR)
