### PR TITLE
Atualiza link recuperação dinâmica keycloak env

### DIFF
--- a/conf-base.php
+++ b/conf-base.php
@@ -19,6 +19,7 @@ return [
         'token_endpoint'        => env('TOKEN_ENDPOINT', ''),
         'user_info_endpoint'    => env('USER_INFO_ENDPOINT', ''),
         'redirect_uri'          => env('REDIRECT_URI', ''),
+        'reset_password_url'    => env('RESET_PASSWORD_URL', ''),
     ],
 
     // CEP API

--- a/views/panel/index.php
+++ b/views/panel/index.php
@@ -309,16 +309,10 @@ if (isset($_SESSION['not_admin_error'])) {
                 <section class="clearfix menu-stats">
                     <div>
                         <div class="clearfix">
-                            <a href="https://dev.id.org.br/auth/realms/saude/account/password" target="_blank" class="btn btn-secound" title="<?php \MapasCulturais\i::_e('Trocar Senha'); ?>">
+                            <?php $authConfig = $app->getConfig('auth.config'); ?>
+                            <a href="<?= $authConfig['reset_password_url']; ?>" target="_blank" class="btn btn-secound" title="<?php \MapasCulturais\i::_e('Trocar Senha'); ?>">
                                 <i class="fa fa-lock alignleft icon-fa" aria-hidden="true"></i>
                                 <?php \MapasCulturais\i::_e('Trocar Senha'); ?></a>
-                        </div>
-                    </div>
-                    <div>
-                        <div class="clearfix">
-                            <a href="https://dev.id.org.br/auth/realms/saude/login-actions/reset-credentials?client_id=DigitalSaude" class="btn btn-secound" title="<?php \MapasCulturais\i::_e('Em casos que você não venha lembrar da senha atual para trocar a sua senha.'); ?>" target="_blank">
-                                <i class="fa fa-unlock-alt alignleft icon-fa" aria-hidden="true"></i>
-                                <?php \MapasCulturais\i::_e('Esqueci a senha'); ?></a>
                         </div>
                     </div>
                     <div>


### PR DESCRIPTION
Responsáveis:  @victorMagalhaesPacheco 

### Descrição

Ao estar logado dentro do mapa da saúde e o usuário(a) deseja alterar a senha, o mesmo deve acessar o painel e recuperar senha e será redirecionado para o id saúde. Acontece que o link de recuperação de senha está apontando para homologação mesmo em produção, ou seja, foi adicionado hard coded e não tratado por ambiente.

A solução proposta no PR é adicionar via variável de ambiente o link e mudar de acordo com o ambiente.

`RESET_PASSWORD_URL=DOMINIO/auth/realms/REALM/account/password`

### Passos a passo para teste

1. Fazer login no mapa da saúde e id saúde
2. Acessar o "Painel de Controle"
3. Clicar no "Alterar senha" em seguida será redirecionado para o AMBIENTE CORRETO
4. Segue o fluxo padrão de alteração de senha

### Observações

Não se aplica

## Checklist para criação do PR

- [ ] Testes foram implementados (novos ou não)
- [x] Issue foi definida no PR (Linked Issue na coluna à direita da página)
- [x] Pessoas contribuidoras foram definidas no PR (Assigners no PR)
