### PR TITLE
Lista somente projetos, subprojetos e oportunidades habilitadas

### DIFF
--- a/Theme.php
+++ b/Theme.php
@@ -191,6 +191,13 @@ class Theme extends BaseV1\Theme{
                 'required' => \MapasCulturais\i::__('Categorias é obrigatório'),
             ];
         });
+
+        /** 
+         * Substitui template da listagem de oportunidades 
+         */ 
+        $app->hook('view.partial(entity-opportunities--item).params', function (&$__data, &$__template) { 
+            $__template = 'module-EntityOpportunities/entity-opportunities--item'; 
+        }); 
     }
 
     public static function setStatusOwnerOpportunity($opportunity, $note) {

--- a/layouts/parts/module-EntityOpportunities/entity-opportunities--item.php
+++ b/layouts/parts/module-EntityOpportunities/entity-opportunities--item.php
@@ -1,0 +1,79 @@
+<?php
+
+use MapasCulturais\i;
+use MapasCulturais\Entities\Opportunity;
+
+/**
+ * Adicionado essas dependências para o funcionamento do componente do angular para buscar o(s) agente(s)
+ */
+$this->bodyProperties['ng-app'] = "entity.app";
+$this->bodyProperties['ng-controller'] = "EntityController";
+
+$this->jsObject['angularAppDependencies'][] = 'entity.module.opportunity';
+$this->jsObject['angularAppDependencies'][] = 'ui.sortable';
+
+// Se a rora for diferente de edição, então passa a entidade opportunity, mas se for edição então pode ser o lançamento de selos, devido ao conflito do objectjs
+if ($this->controller->action != 'edit') {
+    $this->addEntityToJs($opportunity);
+}
+
+$this->addOpportunityToJs($opportunity);
+
+$this->addOpportunitySelectFieldsToJs($opportunity);
+
+if ($this->isEditable()) {
+    $this->addEntityTypesToJs($opportunity);
+    $this->addTaxonoyTermsToJs('tag');
+}
+
+$this->includeAngularEntityAssets($opportunity);
+
+
+$avatar = $opportunity->avatar ? $opportunity->avatar->transform('avatarSmall') : null;
+
+$url = $this->isEditable() ? $opportunity->editUrl : $opportunity->singleUrl;
+// $entity = $app->repo('ProjectOpportunity')->find();
+
+?>
+<article class="objeto card-info-opportunity" ng-controller="OpportunityController">
+    <?php if($opportunity->status == 0): ?>
+        <p class="alert warning"><?php i::_e('Esta oportunidade é um rascunho')?></p>
+    <?php endif; ?>
+    <div class="card-info-header">
+        <?php if ($avatar) : ?>
+            <img src="<?php echo $avatar->url ?>" class="avatar-card-info-opportunity">
+        <?php else : ?>
+            <img src="<?php $this->asset('img/avatar--opportunity.png'); ?>" alt=""  class="avatar-card-info-opportunity" />
+        <?php endif; ?>
+
+        <span>
+            <a href="<?php echo $url ?>"><?php echo $opportunity->name ?></a>
+            <?php $this->part('singles/opportunity-about--registration-dates', ['entity' => $opportunity, 'disable_editable' => true]) ?>
+        </span>
+    </div>
+    <div class="card-info-content">
+        <?php //if ($opportunity->status == Opportunity::STATUS_DRAFT) : ?>
+            <em><?php //i::_e('(Rascunho)') ?></em>
+        <?php //endif; 
+        $this->part('singles/opportunity-registrations--form', ['entity' => $opportunity, 'show_button_access_registration' => true]) 
+        ?>
+
+    </div>
+
+    <!-- <div class="entity-opportunity--content pad-left-10">
+       
+        <div class="">
+           
+        </div>
+        <?php //if ($opportunity->status == Opportunity::STATUS_DRAFT) : ?>
+            <em><?php //i::_e('(Rascunho)') ?></em>
+        <?php //endif; ?>
+        <br>
+        <div>
+            <?php
+            //$this->part('singles/opportunity-registrations--form', ['entity' => $opportunity]) ?>
+        </div>
+    </div> -->
+
+
+</article>

--- a/layouts/parts/module-EntityOpportunities/entity-opportunities--item.php
+++ b/layouts/parts/module-EntityOpportunities/entity-opportunities--item.php
@@ -32,7 +32,6 @@ $this->includeAngularEntityAssets($opportunity);
 $avatar = $opportunity->avatar ? $opportunity->avatar->transform('avatarSmall') : null;
 
 $url = $this->isEditable() ? $opportunity->editUrl : $opportunity->singleUrl;
-// $entity = $app->repo('ProjectOpportunity')->find();
 
 ?>
 <article class="objeto card-info-opportunity" ng-controller="OpportunityController">
@@ -52,28 +51,8 @@ $url = $this->isEditable() ? $opportunity->editUrl : $opportunity->singleUrl;
         </span>
     </div>
     <div class="card-info-content">
-        <?php //if ($opportunity->status == Opportunity::STATUS_DRAFT) : ?>
-            <em><?php //i::_e('(Rascunho)') ?></em>
-        <?php //endif; 
-        $this->part('singles/opportunity-registrations--form', ['entity' => $opportunity, 'show_button_access_registration' => true]) 
+        <?php
+            $this->part('singles/opportunity-registrations--form', ['entity' => $opportunity, 'show_button_access_registration' => true]) 
         ?>
-
     </div>
-
-    <!-- <div class="entity-opportunity--content pad-left-10">
-       
-        <div class="">
-           
-        </div>
-        <?php //if ($opportunity->status == Opportunity::STATUS_DRAFT) : ?>
-            <em><?php //i::_e('(Rascunho)') ?></em>
-        <?php //endif; ?>
-        <br>
-        <div>
-            <?php
-            //$this->part('singles/opportunity-registrations--form', ['entity' => $opportunity]) ?>
-        </div>
-    </div> -->
-
-
 </article>

--- a/layouts/parts/singles/project-list.php
+++ b/layouts/parts/singles/project-list.php
@@ -18,7 +18,19 @@ if ($entity instanceof MapasCulturais\Entities\Project) {
 ?>
 
 <div class="widget">
-    <?php foreach ($projects as $project) : ?>
+    <?php 
+    foreach ($projects as $project) : 
+        $opportunities = $project->getOpportunities(Opportunity::STATUS_DRAFT);
+        $opportunities = array_filter($opportunities, function($opportunity) {
+            if($opportunity->status > 0 || $opportunity->canUser('modify')) {
+                return $opportunity;
+            }
+        });
+
+        if(count($opportunities) == 0) {
+            continue;
+        }
+    ?>
         <h2 style="color: black;">
             <span><?php echo $project->name; ?></span>
         </h2>
@@ -27,11 +39,12 @@ if ($entity instanceof MapasCulturais\Entities\Project) {
 
             <?php $this->applyTemplateHook('entity-opportunities', 'begin'); ?>
             <?php
-            foreach ($project->getOpportunities(Opportunity::STATUS_DRAFT) as $opportunity) : ?>
-
+            foreach ($opportunities as $opportunity) : 
+            ?>
                 <?php $this->part('entity-opportunities--item', ['opportunity' => $opportunity, 'entity' => $entity]) ?>
                 <br>
-            <?php endforeach; ?>
+            <?php 
+            endforeach; ?>
 
 
             <?php $this->applyTemplateHook('entity-opportunities', 'end'); ?>

--- a/layouts/parts/singles/project-registrations.php
+++ b/layouts/parts/singles/project-registrations.php
@@ -16,8 +16,10 @@ $parent = $entity->parent;
 <div id="inscricoes" class="aba-content">
 
     <?php foreach ($entity->getOpportunities(Opportunity::STATUS_DRAFT) as $opportunity) : ?>
-        <?php $this->part('entity-opportunities--item', ['opportunity' => $opportunity, 'entity' => $entity]) ?>
-        <br>
+        <?php if($opportunity->status > 0 || $opportunity->canUser('modify')): ?>
+            <?php $this->part('entity-opportunities--item', ['opportunity' => $opportunity, 'entity' => $entity]) ?>
+            <br>
+        <?php endif; ?>
     <?php endforeach; ?>
 
     <?php $this->applyTemplateHook('tab-inscricoes', 'begin'); ?>


### PR DESCRIPTION
Responsáveis:  @victorMagalhaesPacheco 

### Descrição

Na listagem de projetos, subprojetos e oportunidades estavam mostrando as entidades mesmo que em "rascunho" e "arquivada". Entretanto deve aparecer somente os projetos, subprojetos e oportunidades com a situação habilitada.

O procedimento foi feito um cherry pick baseado no commit https://github.com/EscolaDeSaudePublica/Saude/commit/e71b49519048beb1e7e2052e5f3b694b4fb38966

### Passos a passo para teste

1. Criar projeto
2. Criar subprojeto
3. Criar oportunidades no subprojeto
4. Alterar as situações dos projetos ou subprojetos ou oportunidades para arquivadas ou para rascunho
5. Ao acessar o projeto (pai) o sistema não deve mostrar as entidades com situações diferente do que habilitado.

### Observações

Não se aplica

## Checklist para criação do PR

- [ ] Testes foram implementados (novos ou não)
- [x] Issue foi definida no PR (Linked Issue na coluna à direita da página)
- [x] Pessoas contribuidoras foram definidas no PR (Assigners no PR)
