### PR TITLE
Feature/limite inscricoes projetos

### DIFF
--- a/Theme.php
+++ b/Theme.php
@@ -210,7 +210,7 @@ class Theme extends BaseV1\Theme{
     {
         $app = App::i();
 
-        $app->hook('template(project.edit.tab-about-service):after', function () {
+        $app->hook('template(project.<<*>>.tab-about-service):after', function () {
             $entity = $this->controller->requestedEntity;
             $this->part('singles/project-newfields', ['entity' => $entity]);
         });

--- a/Theme.php
+++ b/Theme.php
@@ -5,6 +5,7 @@ use Exception;
 use MapasCulturais\Themes\BaseV1;
 use MapasCulturais\App;
 use MapasCulturais\Entities;
+use MapasCulturais\Entities\Project;
 use MapasCulturais\Definitions;
 use MapasCulturais\i;
 USE MapasCulturais\Entities\Registration;
@@ -198,6 +199,71 @@ class Theme extends BaseV1\Theme{
         $app->hook('view.partial(entity-opportunities--item).params', function (&$__data, &$__template) { 
             $__template = 'module-EntityOpportunities/entity-opportunities--item'; 
         }); 
+
+
+        $this->validateRegistrationLimitPerOwnerProject();
+       
+    }
+
+
+    private function validateRegistrationLimitPerOwnerProject()
+    {
+        $app = App::i();
+
+        $app->hook('template(project.edit.tab-about-service):after', function () {
+            $entity = $this->controller->requestedEntity;
+            $this->part('singles/project-newfields', ['entity' => $entity]);
+        });
+
+        $thisTheme = $this;
+        $app->hook("entity(Registration).validations", function(&$validations) use($thisTheme) {  
+            $validations['owner']['$app->view->validateRegistrationLimitPerOwnerProjectRegistration($this)'] = \MapasCulturais\i::__('Foi excedido o limite de inscrições para este agente responsável no projeto.');   
+        });
+    }
+
+    function validateRegistrationLimitPerOwnerProjectRegistration($registration)
+    { 
+        $app = App::i();
+
+        $opportunity = $registration->opportunity;
+        
+        if (is_null($opportunity->parent) && $opportunity->ownerEntity instanceof Project) {
+            $project = $opportunity->ownerEntity;
+            $limit = $project->registrationLimitPerOwnerProject;
+            while (!$limit && $project->parent) {
+                $project = $project->parent;
+                $limit = $project->registrationLimitPerOwnerProject;
+            }
+
+            if (!$limit) {
+                return true;
+            }
+            
+            $projectIds = $project->getChildrenIds();
+            $projectIds[] = $project->id;
+
+            $dql = "SELECT 
+                r.id
+            FROM 
+                MapasCulturais\\Entities\\Registration r 
+            WHERE
+                r.owner = :owner AND
+                r.opportunity in (
+                    SELECT o FROM MapasCulturais\\Entities\\ProjectOpportunity o WHERE o.ownerEntity in (:projectIds) 
+                 ) 
+            ";  
+
+            $query = $app->em->createQuery($dql);
+
+            $query->setParameter('owner', $registration->owner);
+            $query->setParameter('projectIds', $projectIds);
+            
+            $result = $query->getScalarResult();
+
+            return (int)$limit > count($result);
+        }
+
+        return true;
     }
 
     public static function setStatusOwnerOpportunity($opportunity, $note) {
@@ -324,6 +390,14 @@ class Theme extends BaseV1\Theme{
         $this->registerOpportunityMetadata('labelCustomRules', [
             'label' => 'Label do regulamento',
             'type' => 'text'
+        ]); 
+
+        // @todo necessário implementar validação do quantitativo de inscrições por projetos pai, o valor não deve ser maior que os valores definidos nos projetos pai e avó
+        $this->registerProjectMetadata('registrationLimitPerOwnerProject', [
+            'label' => \MapasCulturais\i::__('Número máximo de inscrições por agente responsável no projeto'),
+            'validations' => array(
+                "v::intVal()" => \MapasCulturais\i::__("O número máximo de inscrições por agente responsável no projeto deve ser um número inteiro")
+            )
         ]); 
 
         $app = App::i();

--- a/Theme.php
+++ b/Theme.php
@@ -215,8 +215,7 @@ class Theme extends BaseV1\Theme{
             $this->part('singles/project-newfields', ['entity' => $entity]);
         });
 
-        $thisTheme = $this;
-        $app->hook("entity(Registration).validations", function(&$validations) use($thisTheme) {  
+        $app->hook("entity(Registration).validations", function(&$validations) {  
             $validations['owner']['$app->view->validateRegistrationLimitPerOwnerProjectRegistration($this)'] = \MapasCulturais\i::__('Foi excedido o limite de inscrições para este agente responsável no projeto.');   
         });
     }

--- a/Theme.php
+++ b/Theme.php
@@ -210,7 +210,7 @@ class Theme extends BaseV1\Theme{
     {
         $app = App::i();
 
-        $app->hook('template(project.<<*>>.tab-about-service):after', function () {
+        $app->hook('template(project.<<*>>.entity-opportunities):begin', function () {
             $entity = $this->controller->requestedEntity;
             $this->part('singles/project-newfields', ['entity' => $entity]);
         });

--- a/assets/js/ng.entity.module.opportunity.js
+++ b/assets/js/ng.entity.module.opportunity.js
@@ -2208,10 +2208,10 @@ module.controller('OpportunityController', ['$scope', '$rootScope', '$location',
         RegistrationService.register(registration, idOpportunity).success(function(rs){
             if (typeof rs.error !== 'undefined') {
                 if (rs.data.owner) {
-                    MapasCulturais.Messages.error(rs.data.owner);
+                    MapasCulturais.Messages.error(rs.data.owner[0]);
                 }
             } else {
-                document.location = rs.editUrl;
+               document.location = rs.editUrl;
             }
         });
     };

--- a/layouts/parts/singles/project-newfields.php
+++ b/layouts/parts/singles/project-newfields.php
@@ -1,0 +1,7 @@
+<?php if ( $this->isEditable() ): ?>
+<p>
+    <span class="label <?php echo ($entity->isPropertyRequired($entity,"registrationLimitPerOwnerProject") && $editEntity? 'required': '');?>"><?php \MapasCulturais\i::_e("Número máximo de inscrições por agente responsável no projeto");?></span><br>
+    <span class="registration-help"><?php \MapasCulturais\i::_e("Zero (0) significa sem limites");?></span><br>
+    <span class="js-editable" data-edit="registrationLimitPerOwnerProject" data-original-title="<?php \MapasCulturais\i::esc_attr_e("Número máximo de inscrições por agente responsável no projeto");?>" data-emptytext="<?php \MapasCulturais\i::esc_attr_e("Insira o número máximo de inscrições por agente responsável por projeto");?>"><?php echo $entity->registrationLimitPerOwnerProject ? $entity->registrationLimitPerOwnerProject : '0'; ?></span>
+</p>
+<?php endif; ?>

--- a/layouts/parts/singles/project-newfields.php
+++ b/layouts/parts/singles/project-newfields.php
@@ -1,7 +1,9 @@
 <?php if ( $this->isEditable() ): ?>
-<p>
-    <span class="label <?php echo ($entity->isPropertyRequired($entity,"registrationLimitPerOwnerProject") && $editEntity? 'required': '');?>"><?php \MapasCulturais\i::_e("Número máximo de inscrições por agente responsável no projeto");?></span><br>
-    <span class="registration-help"><?php \MapasCulturais\i::_e("Zero (0) significa sem limites");?></span><br>
-    <span class="js-editable" data-edit="registrationLimitPerOwnerProject" data-original-title="<?php \MapasCulturais\i::esc_attr_e("Número máximo de inscrições por agente responsável no projeto");?>" data-emptytext="<?php \MapasCulturais\i::esc_attr_e("Insira o número máximo de inscrições por agente responsável por projeto");?>"><?php echo $entity->registrationLimitPerOwnerProject ? $entity->registrationLimitPerOwnerProject : '0'; ?></span>
-</p>
+    <section class="highlighted-message clearfix">
+        <p>
+            <span class="label <?php echo ($entity->isPropertyRequired($entity,"registrationLimitPerOwnerProject") && $editEntity? 'required': '');?>"><?php \MapasCulturais\i::_e("Número máximo de inscrições por agente responsável no projeto");?></span><br>
+            <span class="registration-help"><?php \MapasCulturais\i::_e("Zero (0) significa sem limites");?></span><br>
+            <span class="js-editable" data-edit="registrationLimitPerOwnerProject" data-original-title="<?php \MapasCulturais\i::esc_attr_e("Número máximo de inscrições por agente responsável no projeto");?>" data-emptytext="<?php \MapasCulturais\i::esc_attr_e("Insira o número máximo de inscrições por agente responsável por projeto");?>"><?php echo $entity->registrationLimitPerOwnerProject ? $entity->registrationLimitPerOwnerProject : '0'; ?></span>
+        </p>
+    </section>
 <?php endif; ?>


### PR DESCRIPTION
Responsáveis:  @victorMagalhaesPacheco 

### Descrição

No atual ambiente do mapas a ferramenta permite realizar o gerenciamento de inscrições do agente responsável por oportunidade, entretanto a funcionalidade para gerenciar por projetos com N subprojetos e N oportunidade não existe até o momento. Foi implementado para que cada projeto tenha um campo **"Número máximo de inscrições por agente responsável no projeto"** que irá limitar a quantidade de inscrições para o agente responsável no projeto independentemente do controle das oportunidade.

![Captura de tela de 2021-12-15 10-18-48](https://user-images.githubusercontent.com/3487411/146193804-dab7f053-d04f-41af-98bf-0486bd6fbf99.png)


Exemplo de projetos, subprojetos e oportunidades

- Projeto 1 **(10 inscrições por agente)**
   - Subprojeto 1 **(3 inscrições por agente)**
      - Oportunidade 1 (controle interno de inscrições)
      - Oportunidade 2 (controle interno de inscrições)
   - Subprojeto 2 **(2 inscrições por agente)**
      - Oportunidade 3 (controle interno de inscrições)
      - Oportunidade 4 (controle interno de inscrições)
   - Subprojeto 3 **(5 inscrições por agente)**
      - Oportunidade 5 (controle interno de inscrições)
      - Oportunidade 6 (controle interno de inscrições)

### Passos a passo para teste

1. Cria projetos e definir um número de inscrições por agente
2. Criar subprojetos e definir o número máximo de inscrições por agente
3. Criar oportunidades dentro dos subprojetos com controle de inscrições "0" que significa sem limite na oportunidade
4. Realizar inscrições com o mesmo agente nas oportunidades dentro de um subprojeto
5. Ao chegar no límite de inscrições definido no subprojeto o sistema deve apresentar uma mensagem "Foi excedido o limite de inscrições para este agente responsável no projeto." e impedir que as inscrições sejam realizadas.

### Observações

Importante realizar os teste com e sem subprojetos.

## Checklist para criação do PR

- [ ] Testes foram implementados (novos ou não)
- [x] Issue foi definida no PR (Linked Issue na coluna à direita da página)
- [x] Pessoas contribuidoras foram definidas no PR (Assigners no PR)
