### PR TITLE
Correção do problema em quando há múltiplas oportunidade dentro da mesma oportunidade

### DIFF
--- a/views/panel/registrations.php
+++ b/views/panel/registrations.php
@@ -27,10 +27,13 @@ error_reporting(E_ALL);
 
     $unique_opportunities = [];
     foreach($sent as $s){
-        if(!array_key_exists($s->opportunity->ownerEntity->id , $unique_opportunities)){
-            $unique_opportunities[$s->opportunity->ownerEntity->id] = $s;
+        if($s->opportunity->parent == null){
+            $unique_opportunities[$s->id] = $s;
         }
     }
+
+    $unique_opportunities = array_reverse($unique_opportunities);
+
  ?>
 
 <div class="panel-list panel-main-content">


### PR DESCRIPTION
Responsáveis:  @pedrovitor074 

### Descrição

Quando havia múltiplas oportunidades dentro do mesmo projeto e não estavam em ordem de fases, o sistema não estava mostrando no menu superior todas as inscrições. 

### Passos a passo para teste

Criar um projeto com múltiplas oportunidades, se inscrever em todas, e depois ir até minhas inscrições, verificar se todos as oportunidades estão aparecendo.

### Observações

Não se aplica

## Checklist para criação do PR

- [ ] Testes foram implementados (novos ou não)
- [x] Issue foi definida no PR (Linked Issue na coluna à direita da página)
- [x] Pessoas contribuidoras foram definidas no PR (Assigners no PR)
