### PR TITLE
Remove status para o candidato

### DIFF
--- a/Theme.php
+++ b/Theme.php
@@ -206,6 +206,13 @@ class Theme extends BaseV1\Theme{
         }); 
 
 
+        /**
+         * Oculta as situaões na página de inscrito
+         */
+        $app->hook('view.partial(singles/registration-single--header):after', function () use ($app) {
+            $app->view->enqueueScript('app', 'hideinfo', 'js/hideinfo.js');
+        });
+
         $this->validateRegistrationLimitPerOwnerProject();
        
     }

--- a/assets/js/hideinfo.js
+++ b/assets/js/hideinfo.js
@@ -1,0 +1,4 @@
+$(document).ready(function () {
+    $(".registration-fieldset .status").hide();
+});
+

--- a/layouts/parts/panel-registration.php
+++ b/layouts/parts/panel-registration.php
@@ -27,19 +27,6 @@ if (isset($_GET['id']) && $_GET['id'] == $registration->id) {
     <small>
         <strong>Inscrição:</strong> <?php echo $registration->number; ?>
     </small> <br>
-
-    <small>
-        <!-- verifica se o resultado já foi publicado antes de exibir o status -->
-        <?php if ($registration->opportunity->publishedRegistrations) : ?>
-            <td class="registration-status-col">
-                <strong>Status: </strong><?php echo RegistrationStatus::getStatusNameById($registration->status); ?>
-
-        <?php else : ?>
-            <td class="registration-status-col statuspend">
-                <strong>Status: </strong><?php echo RegistrationStatus::getStatusNameById($registration->status); ?>
-
-        <?php endif; ?>
-    </small><br>
     <?php $this->part('registration/phases-and-resources.php', 
         ['registration' => $registration]
     ); ?>

--- a/layouts/parts/registration/opportunity-phases-details.php
+++ b/layouts/parts/registration/opportunity-phases-details.php
@@ -11,7 +11,6 @@
     <div class="user-oportunity-details">
         <div>
             <small><strong>Inscrição da fase: <?php echo count($registration) == 0 ? 'Não inscrito' : $registration[0]->number ?></strong></small><br>
-            <?php echo count($registration) > 0 ? '<small><strong>Status:</strong>'. RegistrationStatus::getStatusNameById($registration[0]->status) .'</small><br>' : '';?>
             <?php 
                 if(count($registration) > 0 && $registration[0]->canUser('sendClaimMessage')){
                     if($resources == false && ($rec['open'] == 1 && $rec['close'] == 1)){  ?>

--- a/layouts/parts/singles/opportunity-registrations--user-registrations.php
+++ b/layouts/parts/singles/opportunity-registrations--user-registrations.php
@@ -43,9 +43,6 @@ if (!empty($registrations)) {
                         <?php \MapasCulturais\i::_e("Nota final"); ?>
                     </th>
                 <?php endif; ?>
-                <th class="registration-status-col" style="text-align: center;width: 20%">
-                    <?php \MapasCulturais\i::_e("Status"); ?>
-                </th>
             </tr>
         </thead>
         <tbody>
@@ -112,21 +109,6 @@ if (!empty($registrations)) {
                                 }
                         ?>
                     <?php endif; ?>
-                    <?php $this->applyTemplateHook('user-registration-table--registration', 'end', $reg_args); ?>
-
-                    <?php $this->applyTemplateHook('user-registration-table--registration--status', 'begin', $reg_args);?>
-                    <!-- Apenas mosta o status quando a oportinudade já foi publicada -->
-                    <?php if ($registration->opportunity->publishedRegistrations) : ?>
-                        <td class="registration-status-col <?php echo RegistrationStatus::statusColorById($registration->status); ?>" style="text-align: center; font-size: 11px;">
-                            <?php $this->part('singles/tooltip', ['title' => RegistrationStatus::statusTitleById($registration->status), 
-                            'chield' => RegistrationStatus::getStatusNameById($registration->status)]); ?>
-                        </td>
-                    <?php else : ?>
-                        <td class="registration-status-col statuspend" style="text-align: center; font-size: 11px;">
-                            <?php $this->part('singles/tooltip', ['title' => 'Ainda não avaliada.', 'chield' => 'Pendente']); ?>
-                        </td>
-                    <?php endif; ?>
-
                     <?php $this->applyTemplateHook('user-registration-table--registration', 'end', $reg_args); ?>
                 </tr>
             <?php endforeach; ?>


### PR DESCRIPTION
Responsáveis:  @pedrovitor074 

Linked Issue:  https://github.com/EscolaDeSaudePublica/mapadasaude/issues/615

### Descrição

Ocultar informações de status (situação) para o candidato inscrito



### 🖥 Passos a passo para teste

1. Criar oportunidade
2. realizar inscrição
3. Ao acessar página de minha inscrição com fases, tabela da oportunidade de inscrições e na tela de inscrições não deve aparecer o status


## Checklist para criação do PR

- [ ] Testes foram implementados (novos ou não)
- [x] Issue foi definida no PR (Linked Issue na coluna à direita da página)
- [x] Pessoas contribuidoras foram definidas no PR (Assigners no PR)
