### PR TITLE
#610 Correção do botão salvar para depois

### DIFF
--- a/assets/js/editable.js
+++ b/assets/js/editable.js
@@ -830,9 +830,9 @@ MapasCulturais.Editables = {
                         let findDuplicates = arr => arr.filter((item, index) => arr.indexOf(item) != index)
                         findDuplicates(unknow_errors)
                         // CASO TENHA MAIS DE UM CAMPO OBRIGATÓRIO
-                        if (unknow_errors.length > 0) {
+                        /*if (unknow_errors.length > 0) {
                             MapasCulturais.Messages.error('Confira os campos obrigatórios.')
-                        }
+                        }*/
                     }
 
                     $submitButton.data('clicked', false);


### PR DESCRIPTION
Responsáveis:  
@FernandaNascimento26 
 

Linked Issue:  

[#610](https://app.zenhub.com/workspaces/mapa-da-sade---dev-60f894f541f910001066bfd9/issues/escoladesaudepublica/mapadasaude/610)

### Descrição

Atualmente o botão salvar para depois não permite salvar, alertando sobre campos serem obrigatórios, porém o intuito de salvar como rascunho é salvar de forma incompleta para depois. 

O objetivo da atividade consiste em  alterar condição de salvar para depois mesmo que existam campos obrigatórios não preenchidos. 


### 🖥 Passos a passo para teste

1. Acessar ou criar uma oportunidade que contenha campos obrigatórios
2. Tentar se inscrever ou alterar seus dados na referida oportunidade
2. Não preencher os campos obrigatórios;
3. Clicar no botão salvar para depois;


## Checklist para criação do PR

- [ ] Testes foram implementados (novos ou não)
- [x] Issue foi definida no PR (Linked Issue na coluna à direita da página)
- [x] Pessoas contribuidoras foram definidas no PR (Assigners no PR)
