### PR TITLE
#631 Sincronizar campos de opções presentes no menu 'Meu Perfil' e Menu lateral esquerdo

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -3560,6 +3560,7 @@ body.editable #main-section {
 
 .sidebar-panel {
   display: none;
+  margin-top: 20px;
 }
 
 @media screen and (min-width: 768px) {

--- a/layouts/parts/panel-nav.php
+++ b/layouts/parts/panel-nav.php
@@ -41,16 +41,16 @@
 
         <?php if($app->isEnabled('opportunities')): ?>
             <?php $this->applyTemplateHook('nav.panel.opportunities','before'); ?>
-            <li><a <?php if($this->template == 'panel/opportunities') echo 'class="active"'; ?> href="<?php echo $app->createUrl('panel', 'opportunities') ?>"><span class="icon icon-opportunity"></span> <?php \MapasCulturais\i::_e("Minhas Oportunidades");?></a></li>
+            <li><a <?php if($this->template == 'panel/opportunities') echo 'class="active"'; ?> href="<?php echo $app->createUrl('panel', 'opportunities') ?>"><i class="fa fa-sticky-note-o" style="margin-right: 5px;"></i> <?php \MapasCulturais\i::_e("Minhas Oportunidades");?></a></li>
             <?php $this->applyTemplateHook('nav.panel.opportunities','after'); ?>
 
             <?php $this->applyTemplateHook('nav.panel.registrations','before'); ?>
-            <li><a <?php if($this->template == 'panel/registrations') echo 'class="active"'; ?> href="<?php echo $app->createUrl('panel', 'registrations') ?>"><span class="icon icon-opportunity"></span> <?php \MapasCulturais\i::_e("Minhas Inscrições");?></a></li>
+            <li><a <?php if($this->template == 'panel/registrations') echo 'class="active"'; ?> href="<?php echo $app->createUrl('panel', 'registrations') ?>"><i class="fa fa-pencil-square-o" style="margin-right: 5px;"></i> <?php \MapasCulturais\i::_e("Minhas Inscrições");?></a></li>
             <?php $this->applyTemplateHook('nav.panel.registrations','after'); ?>
         <?php endif; ?>
 
         <li>
-                <a href="<?php echo $app->createUrl('recursos', 'todos') ?>"><span class="icon icon-opportunity"></span> <?php \MapasCulturais\i::_e("Meus Recursos");?></a></li>
+                <a href="<?php echo $app->createUrl('recursos', 'todos') ?>"><i class="fa fa-exchange" style="margin-right: 5px;"></i> <?php \MapasCulturais\i::_e("Meus Recursos");?></a></li>
 
         <?php if($app->user->is('saasAdmin')): ?>
             <li>
@@ -101,7 +101,7 @@
             <?php $this->applyTemplateHook('nav.panel.adminManagement','after'); ?>
         <?php endif; ?>
             <li>
-                <a style="padding-left: 15px" href="<?php echo $app->createUrl('auth', 'logout'); ?>">
+                <a href="<?php echo $app->createUrl('auth', 'logout'); ?>">
                     <span class="fa fa-sign-out"></span> <?php \MapasCulturais\i::_e("Sair");?>
                 </a>
             </li>

--- a/layouts/parts/panel-nav.php
+++ b/layouts/parts/panel-nav.php
@@ -1,11 +1,11 @@
 <nav id="panel-nav" class="sidebar-panel">
     <ul>
         <?php $app->applyHookBoundTo($this, 'panel.menu:before') ?>
-        <li><a <?php if($this->template == 'panel/index') echo 'class="active"'; ?> href="<?php echo $app->createUrl('panel') ?>"><span class="icon icon-panel"></span> <?php \MapasCulturais\i::_e("Painel");?></a></li>
+        <li><a <?php if($this->template == 'panel/index') echo 'class="active"'; ?> href="<?php echo $app->createUrl('panel') ?>"><span class="icon icon-panel"></span> <?php \MapasCulturais\i::_e("Painel de Controle");?></a></li>
         
         <li>
             <a href="<?php echo $app->createUrl('agente', $app->user->profile->id) ?>">
-                <span class="icon icon-agent"></span> <?php \MapasCulturais\i::_e("Meu Perfil"); ?>
+                <span class="icon icon-agent"></span> <?php \MapasCulturais\i::_e("Meus Dados"); ?>
             </a>
         </li>
 
@@ -100,7 +100,11 @@
             </li>
             <?php $this->applyTemplateHook('nav.panel.adminManagement','after'); ?>
         <?php endif; ?>
-
+            <li>
+                <a style="padding-left: 15px" href="<?php echo $app->createUrl('auth', 'logout'); ?>">
+                    <span class="fa fa-sign-out"></span> <?php \MapasCulturais\i::_e("Sair");?>
+                </a>
+            </li>
         <?php $app->applyHookBoundTo($this, 'panel.menu:after') ?>
     </ul>
 </nav>


### PR DESCRIPTION
Responsáveis:  
@pedrovitor074 
 

Linked Issue:  

[#631](https://app.zenhub.com/workspaces/mapa-da-sade---dev-60f894f541f910001066bfd9/issues/escoladesaudepublica/mapadasaude/631)

### Descrição


 Fazer com que as opções presentes nos menus sejam as mesmas.


### 🖥 Passos a passo para teste

1. Ao entrar no sistema comparar o menu lateral e o menu superior.

## Checklist para criação do PR

- [ ] Testes foram implementados (novos ou não)
- [x] Issue foi definida no PR (Linked Issue na coluna à direita da página)
- [x] Pessoas contribuidoras foram definidas no PR (Assigners no PR)
