### PR TITLE
#631 🐛 correcao do tipo de icone mostrado e adicionado espaço

### DIFF
--- a/layouts/parts/panel-nav.php
+++ b/layouts/parts/panel-nav.php
@@ -102,7 +102,7 @@
         <?php endif; ?>
             <li>
                 <a href="<?php echo $app->createUrl('auth', 'logout'); ?>">
-                    <span class="fa fa-sign-out"></span> <?php \MapasCulturais\i::_e("Sair");?>
+                    <i class="fa fa-sign-out" style="margin-right: 5px;"></i> <?php \MapasCulturais\i::_e("Sair");?>
                 </a>
             </li>
         <?php $app->applyHookBoundTo($this, 'panel.menu:after') ?>


### PR DESCRIPTION
Responsáveis:  
@pedrovitor074 
 

Linked Issue:  

[#631](https://app.zenhub.com/workspaces/mapa-da-sade---dev-60f894f541f910001066bfd9/issues/escoladesaudepublica/mapadasaude/631)

### Descrição


 Fazer com que as opções presentes nos menus sejam as mesmas.


### 🖥 Passos a passo para teste

1. Ao entrar no sistema comparar o menu lateral e o menu superior.

## Checklist para criação do PR

- [ ] Testes foram implementados (novos ou não)
- [x] Issue foi definida no PR (Linked Issue na coluna à direita da página)
- [x] Pessoas contribuidoras foram definidas no PR (Assigners no PR)
