### PR TITLE
#631 🐛 condicional para mostrar o botao meus apps somente para saasAdmin

### DIFF
--- a/layouts/parts/panel-nav.php
+++ b/layouts/parts/panel-nav.php
@@ -75,7 +75,7 @@
             <?php $this->applyTemplateHook('nav.panel.subsite','after'); ?>
         <?php endif; ?>
 
-        <?php if($app->isEnabled('apps')): ?>
+        <?php if($app->isEnabled('apps') && $app->user->is('saasAdmin')): ?>
             <?php $this->applyTemplateHook('nav.panel.apps','before'); ?>
             <li><a <?php if($this->template == 'panel/apps') echo 'class="active"'; ?> href="<?php echo $app->createUrl('panel', 'apps') ?>"><span class="icon icon-api"></span> <?php \MapasCulturais\i::_e("Meus Apps");?></a></li>
             <?php $this->applyTemplateHook('nav.panel.apps','after'); ?>


### PR DESCRIPTION
Responsáveis:  
@pedrovitor074 
 

Linked Issue:  

[#631](https://app.zenhub.com/workspaces/mapa-da-sade---dev-60f894f541f910001066bfd9/issues/escoladesaudepublica/mapadasaude/631)

### Descrição


Esconder o botão meus apps.


### 🖥 Passos a passo para teste

1. Ao entrar no sistema comparar o menu lateral e o menu superior.

## Checklist para criação do PR

- [ ] Testes foram implementados (novos ou não)
- [x] Issue foi definida no PR (Linked Issue na coluna à direita da página)
- [x] Pessoas contribuidoras foram definidas no PR (Assigners no PR)
