### PR TITLE
#626💄alteração na formatação do edit-box após testes em homologação

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -10349,3 +10349,7 @@ nav {
   .modal-border{
     border-top: 8px solid #4CAF50;
   }
+
+  .title-gender{
+    color: black;
+  }

--- a/layouts/parts/agent-owner--field-saude.php
+++ b/layouts/parts/agent-owner--field-saude.php
@@ -59,7 +59,7 @@ foreach (Entities\Agent::getPropertiesMetadata() as $key => $def) {
 
 <!-- Conteúdo do edit-box -->
 <article>
-    <edit-box id="editbox-select-registration-owner_" position="up" cancel-label="<?php \MapasCulturais\i::esc_attr_e("Fechar"); ?>" close-on-cancel='true' spinner-condition="data.registrationSpinner">
+    <edit-box id="editbox-select-registration-owner_" position="bottom" cancel-label="<?php \MapasCulturais\i::esc_attr_e("Fechar"); ?>" close-on-cancel='true' spinner-condition="data.registrationSpinner">
     
         <h5 style="text-align: center;"><b>Identidade de gênero</b></h5>
         

--- a/layouts/parts/singles/agent-form.php
+++ b/layouts/parts/singles/agent-form.php
@@ -76,11 +76,11 @@ $getCat = ProfessionalCategory::getCategoryEntity($entity->id, 'profissionais_ca
             <?php echo $entity->genero;
             ?>
             </span>
-            <edit-box id="editbox-select-registration-owner_<?php echo $entity->id; ?>" position="up" cancel-label="<?php \MapasCulturais\i::esc_attr_e("Fechar"); ?>" close-on-cancel='true' spinner-condition="data.registrationSpinner">
+            <edit-box id="editbox-select-registration-owner_<?php echo $entity->id; ?>" position="bottom" cancel-label="<?php \MapasCulturais\i::esc_attr_e("Fechar"); ?>" close-on-cancel='true' spinner-condition="data.registrationSpinner">
                 
             <!-- Conteúdo do edit-box -->
             <div>
-                <h5 style="text-align: center;"><b>Identidade de gênero<b></h5>
+                <h5 style="text-align: center;"><b>Identidade de gênero</b></h5>
 
                 <b class="title-gender"> Mulher Cis</b>
                 <p>Pessoa do sexo feminino com identidade de gênero consonante, também feminina.</p>


### PR DESCRIPTION
Responsáveis:  
@FernandaNascimento26 
 

Linked Issue:  

[#626](https://app.zenhub.com/workspaces/mapa-da-sade---dev-60f894f541f910001066bfd9/issues/escoladesaudepublica/mapadasaude/626)

### Descrição
Alteração na posição do edit-box e no estilo dos títulos das opções de gênero

### 🖥 Passos a passo para teste

**Oportunidade**

1. Criar uma oportunidade que contenha campo de agente individual ou coletivo do tipo gênero;
2. Tentar se inscrever na oportunidade criada;
3. Clicar no ícone de interrogação contido no titulo do campo do tipo gênero;
4. Visualizar a caixa informativa com explicação para cada uma das opções de gênero.

**Dados do Agente**
1. Editar suas informações contidas em meu perfil -> meus dados;
2. Clicar no ícone de interrogação contido no titulo do campo do tipo gênero;
3.  Visualizar a caixa informativa com explicação para cada uma das opções de gênero.


## Checklist para criação do PR

- [ ] Testes foram implementados (novos ou não)
- [x] Issue foi definida no PR (Linked Issue na coluna à direita da página)
- [x] Pessoas contribuidoras foram definidas no PR (Assigners no PR)
