### PR TITLE
#621 📝 Mensagem para informar mudança de página

### DIFF
--- a/Theme.php
+++ b/Theme.php
@@ -62,6 +62,8 @@ class Theme extends BaseV1\Theme{
         //$this->jsObject['angularAppDependencies'][] = 'taxonomies';
         $app->hook('view.render(<<*>>):before', function() use($app) {
             $this->_publishAssets();
+            //Adicionando o arquivo modal-information.js
+            $app->view->enqueueScript('app', 'modal-information', 'js/modal-information.js');
         });
         //ADICIONANDO SOMENTE QUANDO FOR UMA ROTA DO TIPO DE EDIÇÃO
         $app->hook("template(<<*>>.edit.tabs):end", function() use($app){

--- a/assets/js/modal-information.js
+++ b/assets/js/modal-information.js
@@ -1,20 +1,19 @@
 $(document).ready(function() {
+    //Pegando a URL base do Mapas
+    var url_base = MapasCulturais.baseURL;
     //Pegando a URL atual
     var url_atual = window.location.href;
     //Verificando se é a página de inscrições
-    //OBS: verificar o link nos ambientes de homologação e produção
-    if(url_atual.includes('http://localhost/inscricao/')){
+    if(url_atual.includes(url_base +'inscricao/')){
         $("a").click(function(event) {
             //Salvando o link da variável href
             var href = $(this).attr('href');
-            //Usando um regex para verificar se um texto está contido dentro do outro. Neste caso, verificando se uma dessas expressões está dentro da variável href.
-            //OBS: verificar os links nos ambientes de homologação e produção
-            if(href.match(/http:\/\/localhost\/agente\//) || href.match(/http:\/\/localhost\/oportunidade\//)){
+            //Verificando se a url base do mapas está presente no link
+            if(href.includes(url_base)){
                 event.preventDefault();
                 $('body').append('<div class="remodal modal-border" data-remodal-id="modal-information-message"><button data-remodal-action="close" class="remodal-close"></button><h3>Você está saindo da seção de inscrição</h3><div><h4 style="color: #F26822; font-weight: bold;">Você tem certeza disso?</h4></div><div><p>Ao sair desta página, <b>você não perde sua inscrição,</b><br>ela ficará salva para depois:</p><p>Você poderá continuar esta inscrição em: <br><b>Meu Perfil -> Minhas Inscrições. </b></p></div><br><div style="float: right;"><button data-remodal-action="cancel" class="btn btn-default" title="Sair da resposta" style="margin-right: 15px;"> Voltar</button><a class="btn btn-primary" id="dataComfirmOK" href="'+href+'" >Confirmar</a></form></div></div>');
                 $('[data-remodal-id=modal-information-message]').remodal().open();
             }
         });
-    }
-    
+    } 
 });

--- a/assets/js/modal-information.js
+++ b/assets/js/modal-information.js
@@ -1,0 +1,20 @@
+$(document).ready(function() {
+    //Pegando a URL atual
+    var url_atual = window.location.href;
+    //Verificando se é a página de inscrições
+    //OBS: verificar o link nos ambientes de homologação e produção
+    if(url_atual.includes('http://localhost/inscricao/')){
+        $("a").click(function(event) {
+            //Salvando o link da variável href
+            var href = $(this).attr('href');
+            //Usando um regex para verificar se um texto está contido dentro do outro. Neste caso, verificando se uma dessas expressões está dentro da variável href.
+            //OBS: verificar os links nos ambientes de homologação e produção
+            if(href.match(/http:\/\/localhost\/agente\//) || href.match(/http:\/\/localhost\/oportunidade\//)){
+                event.preventDefault();
+                $('body').append('<div class="remodal modal-border" data-remodal-id="modal-information-message"><button data-remodal-action="close" class="remodal-close"></button><h3>Você está saindo da seção de inscrição</h3><div><h4 style="color: #F26822; font-weight: bold;">Você tem certeza disso?</h4></div><div><p>Ao sair desta página, <b>você não perde sua inscrição,</b><br>ela ficará salva para depois:</p><p>Você poderá continuar esta inscrição em: <br><b>Meu Perfil -> Minhas Inscrições. </b></p></div><br><div style="float: right;"><button data-remodal-action="cancel" class="btn btn-default" title="Sair da resposta" style="margin-right: 15px;"> Voltar</button><a class="btn btn-primary" id="dataComfirmOK" href="'+href+'" >Confirmar</a></form></div></div>');
+                $('[data-remodal-id=modal-information-message]').remodal().open();
+            }
+        });
+    }
+    
+});


### PR DESCRIPTION
by @lucastandy @FernandaNascimento26 

## Objetivo 
 
Como gestor
Quero melhorar a experiência de redirecionamento de páginas durante a inscrição
Para evitar que a pessoa usuária fique sem entender o que está acontecendo caso saia da página de inscrição por acidente 
 
## Contexto 
 
Durante os testes ao clicar sem querer no nome do agente responsável a pessoa é direcionada para outra página e não recebe aviso de que está deixando o ambiente de inscrição. É preciso que qualquer clique que seja dado no ambiente de inscrição e que leve a pessoa a deixar o ambiente, seja informado para que a pessoa saiba o que está acontecendo e possa cancelar a ação se desejar.

(Sugestão: Mostrar uma mensagem: "Você está saindo da seção de inscrição. Você pode continuar sua inscrição pelo menu Minhas Inscrições depois. Tem certeza disso?" - Se a pessoa clicar em 'Sim' a inscrição deve ser salva para posterior edição.)
 
## Escopo 
 
[x] Propor a visualização de mensagem no momento do redirecionamento
[x] Incluir solução no protótipo
 

## Critérios de Aceitação 
 
[x] Aplicar solução no local indicado
Dado que a pessoa usuária clica em algum link que não faça parte da jornada de inscrição
Quando quando ela for ser redirecionada para outra página
então ela recebe uma notificação informando que ela está saindo do ambiente de inscrição e perguntando se ela deseja ou não prosseguir com a ação
 
# Observações 
 
ex: Prototipo 