### PR TITLE
#635 Ocultar exibição da aba 'agenda'

### DIFF
--- a/Theme.php
+++ b/Theme.php
@@ -239,7 +239,17 @@ class Theme extends BaseV1\Theme{
             $app = App::i();
             $html = $this->part('agent-collective--field-saude');
         });
-       
+
+
+        /**
+         * Oculta a aba agenda
+         */
+        $app->hook('view.partial(agenda-singles--tab):after', function($template, &$html){
+            $app = App::i();
+
+                $html = '';
+           
+        });
     }
 
 


### PR DESCRIPTION
Responsáveis:  
@FernandaNascimento26 
 

Linked Issue:  

[#626](https://app.zenhub.com/workspaces/mapa-da-sade---dev-60f894f541f910001066bfd9/issues/escoladesaudepublica/mapadasaude/6)

### Descrição


O objetivo da atividade consiste em ocultar para a experiência da aba **agenda**, tendo em vista que esta opção não se econtra em uso pelo Mapa da Saúde.


### 🖥 Passos a passo para teste

**Inscrições/ Projetos**

1. Verificar nas opções de abas a inexistencia da aba agenda;

**Inscrições/ Projetos**

1. Verificar nas opções nas abas a inexistencia da aba agenda;

**Agentes**

1. Selecionar um agente e verificar nas abas a inexistencia da aba agenda;

**Espaços**

1. Selecionar um espaço e verificar nas abas a inexistencia da aba agenda;


## Checklist para criação do PR

- [ ] Testes foram implementados (novos ou não)
- [x] Issue foi definida no PR (Linked Issue na coluna à direita da página)
- [x] Pessoas contribuidoras foram definidas no PR (Assigners no PR)
