### PR TITLE
#513 Ocultar datas de inicio e fim dos projetos

### DIFF
--- a/layouts/parts/singles/project-about.php
+++ b/layouts/parts/singles/project-about.php
@@ -5,7 +5,9 @@ $editEntity = $this->controller->action === 'create' || $this->controller->actio
 <div id="sobre" class="aba-content">
     <?php $this->applyTemplateHook('tab-about','begin'); ?>
 
-    <?php $this->part('singles/project-about--highlighted-message', ['entity' => $entity]) ?>
+    <!-- Ocultando a parte que chama a datas na criação/edição de um projeto
+    <?php //$this->part('singles/project-about--highlighted-message', ['entity' => $entity]) ?>
+    -->
 
     <div class="ficha-spcultura">
         <?php if($this->isEditable() && $entity->shortDescription && strlen($entity->shortDescription) > 2000): ?>


### PR DESCRIPTION
Responsáveis:  
@FernandaNascimento26 
 

Linked Issue:  

[#513](https://app.zenhub.com/workspaces/mapa-da-sade---dev-60f894f541f910001066bfd9/issues/escoladesaudepublica/mapadasaude/513)

### Descrição


O objetivo da atividade consiste em ocultar as datas de inicio e fim de um projeto, tendo em vista que esta opção não se aplica para projetos e somente para oportunidades.


### 🖥 Passos a passo para teste

**Inscrições/ Projetos**

1. Verificar nas opções de abas a aba **detalhes**;
2. Verificar a inesxistencia do campo de datas;
3. Isso se aplica na visualização do projeto, bem como nas suas configurações de criação e edição
4. Os demais itens permanecem inalterados


## Checklist para criação do PR

- [ ] Testes foram implementados (novos ou não)
- [x] Issue foi definida no PR (Linked Issue na coluna à direita da página)
- [x] Pessoas contribuidoras foram definidas no PR (Assigners no PR)
