### PR TITLE
#512 Retirar a aba inscrições da edição de um projeto

### DIFF
--- a/layouts/parts/singles/project-tabs.php
+++ b/layouts/parts/singles/project-tabs.php
@@ -1,18 +1,23 @@
-<?php $this->applyTemplateHook('tabs','before'); ?>
+<?php $this->applyTemplateHook('tabs', 'before'); ?>
 <ul class="abas clearfix">
-    <?php $this->applyTemplateHook('tabs','begin'); ?>
+    <?php $this->applyTemplateHook('tabs', 'begin'); ?>
 
-    <li class="active"><a href="#inscricoes" rel='noopener noreferrer'><?php \MapasCulturais\i::_e("Inscrições");?></a></li>
-
-    <li class="active"><a href="#sobre" rel='noopener noreferrer'><?php \MapasCulturais\i::_e("Detalhes");?></a></li>
-
-    <?php if(!$entity->isNew()): ?>
-        <li ng-if="data.entity.userHasControl && data.entity.events.length" ><a href="#eventos" rel='noopener noreferrer'><?php \MapasCulturais\i::_e("Status dos eventos");?></a></li>
+    <!-- Verifica se o projeto não está em modo edição para exibir a aba inscrições -->
+    <?php
+    if (!$this->isEditable()) : ?>
+        <li class="active"><a href="#inscricoes" rel='noopener noreferrer'><?php \MapasCulturais\i::_e("Inscrições"); ?></a></li>
     <?php endif; ?>
 
-    <?php if(!($this->controller->action === 'create')):?>
-    <li><a href="#permissao" rel='noopener noreferrer'><?php \MapasCulturais\i::_e("Responsáveis");?></a></li>
-    <?php endif;?>
-    <?php $this->applyTemplateHook('tabs','end'); ?>
+
+    <li class="active"><a href="#sobre" rel='noopener noreferrer'><?php \MapasCulturais\i::_e("Detalhes"); ?></a></li>
+
+    <?php if (!$entity->isNew()) : ?>
+        <li ng-if="data.entity.userHasControl && data.entity.events.length"><a href="#eventos" rel='noopener noreferrer'><?php \MapasCulturais\i::_e("Status dos eventos"); ?></a></li>
+    <?php endif; ?>
+
+    <?php if (!($this->controller->action === 'create')) : ?>
+        <li><a href="#permissao" rel='noopener noreferrer'><?php \MapasCulturais\i::_e("Responsáveis"); ?></a></li>
+    <?php endif; ?>
+    <?php $this->applyTemplateHook('tabs', 'end'); ?>
 </ul>
-<?php $this->applyTemplateHook('tabs','after'); ?>
+<?php $this->applyTemplateHook('tabs', 'after'); ?>


### PR DESCRIPTION
Responsáveis:  
@FernandaNascimento26 
 

Linked Issue:  

[#512](https://app.zenhub.com/workspaces/mapa-da-sade---dev-60f894f541f910001066bfd9/issues/escoladesaudepublica/mapadasaude/512)

### Descrição


O objetivo da atividade consiste em ocultar a aba *inscrições* no momento de criação/edição de um projeto. 

### 🖥 Passos a passo para teste

**Inscrições/ Projetos**

1. Ao criar ou editar um projeto, observar a inexistênca da aba **inscrições**;
2. Quando não estiver em modo edição, a aba inscrições deve aparecer. 


## Checklist para criação do PR

- [ ] Testes foram implementados (novos ou não)
- [x] Issue foi definida no PR (Linked Issue na coluna à direita da página)
- [x] Pessoas contribuidoras foram definidas no PR (Assigners no PR)
