### PR TITLE
#630 Revisar experiência de resgate de uma inscrição de oportunidade no rascunho

### DIFF
--- a/layouts/parts/singles/opportunity-registrations--form.php
+++ b/layouts/parts/singles/opportunity-registrations--form.php
@@ -47,8 +47,11 @@ if  ($entity->isRegistrationOpen()): ?>
                             <find-entity id='find-entity-registration-owner_<?php echo $entity->id; ?>' entity="agent" no-results-text="<?php \MapasCulturais\i::esc_attr_e("Nenhum agente encontrado");?>" select="setRegistrationOwner" opportunityid="<?php echo $entity->id; ?>" api-query='data.relationApiQuery.owner' spinner-condition="data.registrationSpinner"></find-entity>
                             <strong><?php \MapasCulturais\i::_e("Apenas são visíveis os agentes publicados.");?> <a target="_blank" href="<?php echo $app->createUrl('panel', 'agents') ?>"><?php \MapasCulturais\i::_e("Ver mais.");?></a></strong>
                         </edit-box>
-                        <?php if(($entity->ownerEntity->registrationLimitPerOwnerProject == 0) || 
-                                ($entity->ownerEntity->registrationLimitPerOwnerProject != 0 && count($registrations) < $entity->ownerEntity->registrationLimitPerOwnerProject )){ ?>
+                        <?php if(($entity->ownerEntity->registrationLimitPerOwnerProject == 0 && $entity->registrationLimitPerOwner == 0) 
+                                    || ($entity->ownerEntity->registrationLimitPerOwnerProject == 0 && count($registrations) < $entity->registrationLimitPerOwner )
+                                    || ($entity->ownerEntity->registrationLimitPerOwner == 0 && count($registrations) < $entity->registrationLimitPerOwnerProject )
+                                    || (count($registrations) < $entity->registrationLimitPerOwnerProject && count($registrations) < $entity->registrationLimitPerOwner)
+                                ){ ?>
                                 <?php 
                                     if(is_null($unfinished)){ ?>
                                         <a class="btn btn-primary btn-register-opportunity" style="color: #ffffff;" ng-click="register(<?php echo $entity->id; ?>)" rel='noopener noreferrer'><?php \MapasCulturais\i::_e("Fazer inscrição");?></a>


### PR DESCRIPTION
Responsáveis:  
@pedrovitor074 
 

Linked Issue:  

[#630](https://app.zenhub.com/workspaces/mapa-da-sade---dev-60f894f541f910001066bfd9/issues/escoladesaudepublica/mapadasaude/630)

### Descrição

Ajuste sobre esconder o botão quando a oportunidade tem limitações de inscrições.


### 🖥 Passos a passo para teste

**Oportunidade**

1. Criar uma oportunidade para que seja possível a inscrição.
2. Verificar os botões de editar e ver comprovante da inscrição. 



## Checklist para criação do PR

- [ ] Testes foram implementados (novos ou não)
- [x] Issue foi definida no PR (Linked Issue na coluna à direita da página)
- [x] Pessoas contribuidoras foram definidas no PR (Assigners no PR)
