### PR TITLE
#667 Remover disparos de e-mails para edições de inscrição

### DIFF
--- a/Theme.php
+++ b/Theme.php
@@ -148,41 +148,43 @@ class Theme extends BaseV1\Theme{
         /**
          * Ao finalizar o envio das inscrições é enviado um email
          */
-        $app->hook('entity(Registration).send:after', function () use ($app) {
-            $registration = $this;
-            if ($registration->opportunity->mailTitleSendConfirm && $registration->opportunity->mailDescriptionSendConfirm) {
-                $template = 'registration_confirm_custom';
-
-                $dataValue = [
-                    'mailDescriptionSendConfirm' => $registration->opportunity->mailDescriptionSendConfirm,
-                    'name' => $registration->owner->name,
-                    'number' => $registration->number,
-                    'opportunity' => $registration->opportunity->name,
-                    'url_project' => $app->createUrl('panel', 'registrations')
-                ];
-
-                $subject = $registration->opportunity->mailTitleSendConfirm;
-
-            } else {
-                $template = 'registration_confirm_default';
-
-                $dataValue = [
-                    'name' => $registration->owner->name,
-                    'number' => $registration->number,
-                    'opportunity' => $registration->opportunity->name
-                ];
-                $subject = 'Confirmação de inscrição - ' . "#{$dataValue['number']}";
-            }
-
-            $message = $app->renderMailerTemplate($template, $dataValue);
-
-            $app->createAndSendMailMessage([
-                'from' => $app->config['mailer.from'],
-                'to' => $registration->owner->user->email,
-                'bcc' => $registration->opportunity->owner->user->email,
-                'subject' => $subject,
-                'body' => $message['body']
-            ]);          
+        $app->hook('entity(Registration).send:before', function () use ($app) {
+            if(is_null($this->sentTimestamp)){
+                $registration = $this;
+                if ($registration->opportunity->mailTitleSendConfirm && $registration->opportunity->mailDescriptionSendConfirm) {
+                    $template = 'registration_confirm_custom';
+    
+                    $dataValue = [
+                        'mailDescriptionSendConfirm' => $registration->opportunity->mailDescriptionSendConfirm,
+                        'name' => $registration->owner->name,
+                        'number' => $registration->number,
+                        'opportunity' => $registration->opportunity->name,
+                        'url_project' => $app->createUrl('panel', 'registrations')
+                    ];
+    
+                    $subject = $registration->opportunity->mailTitleSendConfirm;
+    
+                } else {
+                    $template = 'registration_confirm_default';
+    
+                    $dataValue = [
+                        'name' => $registration->owner->name,
+                        'number' => $registration->number,
+                        'opportunity' => $registration->opportunity->name
+                    ];
+                    $subject = 'Confirmação de inscrição - ' . "#{$dataValue['number']}";
+                }
+    
+                $message = $app->renderMailerTemplate($template, $dataValue);
+    
+                $app->createAndSendMailMessage([
+                    'from' => $app->config['mailer.from'],
+                    'to' => $registration->owner->user->email,
+                    'bcc' => $registration->opportunity->owner->user->email,
+                    'subject' => $subject,
+                    'body' => $message['body']
+                ]);
+            }          
         });      
 
         /**


### PR DESCRIPTION
Responsáveis:  
@pedrovitor074 
 

Linked Issue:  

[#667](https://app.zenhub.com/workspaces/mapa-da-sade---dev-60f894f541f910001066bfd9/issues/escoladesaudepublica/mapadasaude/667)

### Descrição

Ajustando hook de envio de emails para enviar somente após a finalização do registro. 

## Checklist para criação do PR

- [ ] Testes foram implementados (novos ou não)
- [x] Issue foi definida no PR (Linked Issue na coluna à direita da página)
- [x] Pessoas contribuidoras foram definidas no PR (Assigners no PR)
