### PR TITLE
#633 Identificação de campos Agente responsável e Agente coletivo em outras fases

### DIFF
--- a/Theme.php
+++ b/Theme.php
@@ -288,6 +288,13 @@ class Theme extends BaseV1\Theme{
             $this->part('modals/open-modal-confirm-edit-registration', ["id" => null, "infoModal" => $infoModal, "entity" => $registration]);
         });
 
+        /**
+         * Adicionando campos agentes responsaveis nas fases de uma oportunidade
+         */
+        $app->hook('view.partial(singles/opportunity-registrations--agent-relations).params', function (&$params, &$template) use ($app) {
+            $template = "singles/opportunity-registrations--agent-relations.php";
+            return;
+        });
 
     }
 

--- a/layouts/parts/singles/opportunity-registrations--agent-relations.php
+++ b/layouts/parts/singles/opportunity-registrations--agent-relations.php
@@ -24,7 +24,14 @@ $editEntity = $this->controller->action === 'create' || $this->controller->actio
             <p>
                 <span class="label <?php echo ($entity->isPropertyRequired($entity,$metadata_name) && $editEntity? 'required': '');?>"><?php echo $def->label ?></span> <span class="registration-help">(<?php echo $def->description ?>)</span>
                 <br>
-                <span class="<?php echo $ditable_class ?>" data-edit="<?php echo $metadata_name ?>" data-original-title="<?php echo $def->metadataConfiguration['label'] ?>" data-emptytext="<?php \MapasCulturais\i::esc_attr_e("Selecione uma opção");?>"><?php echo $option_label ?></span>
+                <?php 
+                    $currentValue = $entity->parent->$metadata_name;
+                    if($entity->isOpportunityPhase && $can_edit && ($entity->$metadata_name == null)){ ?>
+                        <span class="<?php echo $ditable_class ?>" data-edit="<?php echo $metadata_name ?>" data-original-title="<?php echo $def->metadataConfiguration['label'] ?>" data-emptytext="<?php \MapasCulturais\i::esc_attr_e("Selecione uma opção");?>"><?php echo $currentValue ?></span>
+                    <?php }else{ ?>
+                        <span class="<?php echo $ditable_class ?>" data-edit="<?php echo $metadata_name ?>" data-original-title="<?php echo $def->metadataConfiguration['label'] ?>" data-emptytext="<?php \MapasCulturais\i::esc_attr_e("Selecione uma opção");?>"><?php echo $option_label ?></span>
+                    <?php }
+                ?>
             </p>
 
         </div>

--- a/layouts/parts/singles/opportunity-registrations--agent-relations.php
+++ b/layouts/parts/singles/opportunity-registrations--agent-relations.php
@@ -4,7 +4,6 @@ $can_edit = $entity->canUser('modifyRegistrationFields');
 $ditable_class = $can_edit ? 'js-editable' : '';
 
 $editEntity = $this->controller->action === 'create' || $this->controller->action === 'edit';
-
 ?>
 <div id="registration-agent-relations" class="registration-fieldset">
     <h4><?php \MapasCulturais\i::_e("Agentes");?></h4>
@@ -25,8 +24,8 @@ $editEntity = $this->controller->action === 'create' || $this->controller->actio
                 <span class="label <?php echo ($entity->isPropertyRequired($entity,$metadata_name) && $editEntity? 'required': '');?>"><?php echo $def->label ?></span> <span class="registration-help">(<?php echo $def->description ?>)</span>
                 <br>
                 <?php 
-                    $currentValue = $entity->parent->$metadata_name;
-                    if($entity->isOpportunityPhase && $can_edit && ($entity->$metadata_name == null)){ ?>
+                    $currentValue = $entity->parent != null ? $entity->parent->$metadata_name : null;
+                    if(!is_null($currentValue) && $entity->isOpportunityPhase && $can_edit && ($entity->$metadata_name == null)){ ?>
                         <span class="<?php echo $ditable_class ?>" data-edit="<?php echo $metadata_name ?>" data-original-title="<?php echo $def->metadataConfiguration['label'] ?>" data-emptytext="<?php \MapasCulturais\i::esc_attr_e("Selecione uma opção");?>"><?php echo $currentValue ?></span>
                     <?php }else{ ?>
                         <span class="<?php echo $ditable_class ?>" data-edit="<?php echo $metadata_name ?>" data-original-title="<?php echo $def->metadataConfiguration['label'] ?>" data-emptytext="<?php \MapasCulturais\i::esc_attr_e("Selecione uma opção");?>"><?php echo $option_label ?></span>


### PR DESCRIPTION
Responsáveis:  
@pedrovitor074 
 

Linked Issue:  

[#633](https://app.zenhub.com/workspaces/mapa-da-sade---dev-60f894f541f910001066bfd9/issues/escoladesaudepublica/mapadasaude/633)

### Descrição

Atualmente quando o administrador de uma oportunidade, ao configurar os campos de agente responsável e agente coletivo na fase inicial de uma oportunidade, ao criar uma segunda fase em diante, as configurações para estes campos não são migradas para a próxima fase e também não aparece a opção para o administrador inserir a configuração na fase seguinte..


### 🖥 Passos a passo para teste

**Oportunidade**

1. Criar uma oportunidade com duas fases;
2. Verificar se o campo agente coletivo está presente nas duas fases.



## Checklist para criação do PR

- [ ] Testes foram implementados (novos ou não)
- [x] Issue foi definida no PR (Linked Issue na coluna à direita da página)
- [x] Pessoas contribuidoras foram definidas no PR (Assigners no PR)
