### PR TITLE
#682 bloqueando o cpf de edição depois de enviado

### DIFF
--- a/Theme.php
+++ b/Theme.php
@@ -296,6 +296,13 @@ class Theme extends BaseV1\Theme{
             return;
         });
 
+        /**
+         * Adicionando hook para mascara e bloqueando o campo cpf de edição.
+         */
+        $app->hook('view.partial(singles/agent-form):before', function() use ($app){
+            $app->view->enqueueScript('app', 'user_edit', 'js/user_edit.js');
+        });
+
     }
 
 

--- a/assets/js/user_edit.js
+++ b/assets/js/user_edit.js
@@ -1,0 +1,7 @@
+$(document).ready(function () {
+    let cpf = $("#user_cpf");
+    let cpf_value = cpf.text().replace(/\D/g, "");
+    if(cpf_value.match( /(^\d{3}\d{3}\d{3}\d{2}$)|(^\d{2}\d{3}\d{3}\d{4}\d{2}$)/)){
+        cpf.editable('toggleDisabled');
+    }
+});

--- a/layouts/parts/singles/agent-form.php
+++ b/layouts/parts/singles/agent-form.php
@@ -52,7 +52,7 @@ $getCat = ProfessionalCategory::getCategoryEntity($entity->id, 'profissionais_ca
         <p class="privado">
             <span class="icon icon-private-info"></span>
             <span class="label"><?php \MapasCulturais\i::_e("CPF/CNPJ"); ?>:</span>
-            <span class="js-editable <?php echo ($entity->isPropertyRequired($entity, "documento") && $editEntity ? 'required' : ''); ?>" data-edit="documento" data-original-title="<?php \MapasCulturais\i::esc_attr_e("CPF/CNPJ"); ?>" data-emptytext="<?php \MapasCulturais\i::esc_attr_e("Informe seu CPF ou CNPJ com pontos, hífens e barras"); ?>">
+            <span id="user_cpf" class="js-editable <?php echo ($entity->isPropertyRequired($entity, "documento") && $editEntity ? 'required' : ''); ?>" data-edit="documento" data-original-title="<?php \MapasCulturais\i::esc_attr_e("CPF/CNPJ"); ?>" data-emptytext="<?php \MapasCulturais\i::esc_attr_e("Informe seu CPF ou CNPJ com pontos, hífens e barras"); ?>">
                 <?php echo $entity->documento; ?>
             </span>
         </p>

--- a/layouts/parts/singles/opportunity-registrations--user-registrations.php
+++ b/layouts/parts/singles/opportunity-registrations--user-registrations.php
@@ -97,7 +97,11 @@ if (!empty($registrations)) {
                                     <a class="btn btn-small btn-primary mt-auto" style="width: 113.81px;" href="<?php echo $registration->singleUrl ?>"><?php \MapasCulturais\i::_e("Editar inscrição"); ?></a>
                                 <?php endif; ?>
                             <?php endif; ?>
-                            <?php $this->applyTemplateHook('user-registration-table--registration--status', 'end', $reg_args); ?>
+                            <?php if($entity->claimDisabled != null): ?>
+                                <?php $this->applyTemplateHook('user-registration-table--registration--status', 'end', $reg_args); ?>
+                            <?php endif; ?>
+
+                            
                         </td>
                         <?php if (
                             $verifyPublish->publishedRegistrations == true


### PR DESCRIPTION
Responsáveis:  
@pedrovitor074 
 

Linked Issue:  

[#682](https://app.zenhub.com/workspaces/mapa-da-sade---dev-60f894f541f910001066bfd9/issues/escoladesaudepublica/mapadasaude/682)

### Descrição

Bloqueando o usuário de apagar o cpf após ter inserido e corrigindo botão do recurso.

## Checklist para criação do PR

- [ ] Testes foram implementados (novos ou não)
- [x] Issue foi definida no PR (Linked Issue na coluna à direita da página)
- [x] Pessoas contribuidoras foram definidas no PR (Assigners no PR)
