### PR TITLE
Validação de CPF/CNPJ na criação e edição de agente

### DIFF
--- a/Theme.php
+++ b/Theme.php
@@ -573,6 +573,13 @@ class Theme extends BaseV1\Theme{
             $app->view->enqueueScript('app', 'user_edit', 'js/user_edit.js');
         });
 
+        /**
+        * Adiciona máscara no input de CPF/CNPJ na modal de criação de agentes
+        */
+        $app->hook('template(panel.agents.panel-header):end', function() use ($app){
+            $app->view->enqueueScript('app', 'agent-creation', 'js/agent-creation.js');
+        });
+
 
          /**
          * Adiciona novos menus no painel

--- a/agent-types.php
+++ b/agent-types.php
@@ -42,6 +42,7 @@ return array(
             'label' => \MapasCulturais\i::__('CPF ou CNPJ'),
             'validations' => array(
                 'required' => \MapasCulturais\i::__('Seu documento deve ser informado.'),
+                'unique' => \MapasCulturais\i::__('Já existe um cadastro vinculado a este CPF! Verifique se você possui outra conta no Mapa da Saúde.'),
                 'v::oneOf(v::cpf(),v::cnpj())' => \MapasCulturais\i::__('O número de documento informado é inválido.')
             ),
             'available_for_opportunities' => true

--- a/assets/js/agent-creation.js
+++ b/assets/js/agent-creation.js
@@ -1,0 +1,6 @@
+$(() => {
+    $("input[name='documento']").on('keydown', function() {
+        if ($(this).val().length > 14) $(this).mask('00.000.000/0000-00')
+        else $(this).mask('000.000.000-009')
+    })
+})


### PR DESCRIPTION
Ao criar e editar um agente foi inserido uma validação para verificar se o CPF/CNPJ já está cadastrado na base de dados. Se já cadastrado, não permitir que seja salvo no banco novamente.