### PR TITLE
Validação de CPF na inscrição de uma oportunidade

### DIFF
--- a/Theme.php
+++ b/Theme.php
@@ -573,6 +573,13 @@ class Theme extends BaseV1\Theme{
             $app->view->enqueueScript('app', 'user_edit', 'js/user_edit.js');
         });
 
+        /**
+        * Adiciona máscara no input de CPF/CNPJ na modal de criação de agentes
+        */
+        $app->hook('template(panel.agents.panel-header):end', function() use ($app){
+            $app->view->enqueueScript('app', 'agent-creation', 'js/agent-creation.js');
+        });
+
 
          /**
          * Adiciona novos menus no painel

--- a/agent-types.php
+++ b/agent-types.php
@@ -42,6 +42,7 @@ return array(
             'label' => \MapasCulturais\i::__('CPF ou CNPJ'),
             'validations' => array(
                 'required' => \MapasCulturais\i::__('Seu documento deve ser informado.'),
+                'unique' => \MapasCulturais\i::__('Já existe um cadastro vinculado a este CPF! Verifique se você possui outra conta no Mapa da Saúde.'),
                 'v::oneOf(v::cpf(),v::cnpj())' => \MapasCulturais\i::__('O número de documento informado é inválido.')
             ),
             'available_for_opportunities' => true

--- a/assets/js/agent-creation.js
+++ b/assets/js/agent-creation.js
@@ -1,0 +1,6 @@
+$(() => {
+    $("input[name='documento']").on('keydown', function() {
+        if ($(this).val().length > 14) $(this).mask('00.000.000/0000-00')
+        else $(this).mask('000.000.000-009')
+    })
+})

--- a/views/indicadores/index.php
+++ b/views/indicadores/index.php
@@ -18,7 +18,7 @@
       list-style-type: none;
       margin: 0;
       padding: 0;
-      width: 50%;
+      width: 33.3%;
       display: table;
       /* Transforma a div numa tabela */
       table-layout: fixed;
@@ -93,15 +93,20 @@
 
 <div class="abas-indicadores">
    <ul class="abas clearfix-indicadores clear">
+   <li class="linhaprincipal active-indicadores"><a href="#forcaTrabalho" rel='noopener noreferrer'>
+            <div class="fa fa-users"></div><?php \MapasCulturais\i::_e(" Força de Trabalho"); ?>
+         </a></li>
       <li class="linhaprincipal active-indicadores"><a href="#instituicoes" rel='noopener noreferrer'>
             <div class="fa fa-building"></div><?php \MapasCulturais\i::_e(" Espaços de Saúde"); ?>
          </a></li>
       <li class="linhaprincipal active-indicadores"><a href="#profissionais" rel='noopener noreferrer'>
-            <div class="fa fa-users"></div><?php \MapasCulturais\i::_e(" Profissionais"); ?>
+            <div class="fa fa-users"></div><?php \MapasCulturais\i::_e(" Agentes"); ?>
          </a></li>
    </ul>
 </div>
 <div class="container-iframe">
+<iframe class="responsive-iframe" id="forcaTrabalho" src="https://metabase.esp.ce.gov.br/public/dashboard/34161172-bcdc-4f6d-a939-6543e4e752ee">
+   </iframe>
    <iframe class="responsive-iframe" id="instituicoes" src="https://metabase.esp.ce.gov.br/public/dashboard/d42b7987-c687-48ad-af5b-fd252585cea4">
    </iframe>
    <iframe class="responsive-iframe" id="profissionais" src="https://metabase.esp.ce.gov.br/public/dashboard/e9f6d26f-3495-4556-a9eb-2a59e387755b">

--- a/views/indicadores/instituicoes-saude.php
+++ b/views/indicadores/instituicoes-saude.php
@@ -1,7 +1,0 @@
-<iframe
-        src="http://metabase.esp.ce.gov.br/public/dashboard/83600e59-babe-4195-a1f0-8091cee040c7"
-        frameborder="0"
-        width="100%"
-        height="1000px"
-        allowtransparency
-></iframe>

--- a/views/indicadores/profissionais-de-saude-medicos.php
+++ b/views/indicadores/profissionais-de-saude-medicos.php
@@ -1,7 +1,0 @@
-<iframe
-        src="http://metabase.esp.ce.gov.br/public/dashboard/9c41f955-daed-46d9-93c7-39cb60e26755"
-        frameborder="0"
-        width="100%"
-        height="1000px"
-        allowtransparency
-></iframe>

--- a/views/indicadores/profissionais-de-saude.php
+++ b/views/indicadores/profissionais-de-saude.php
@@ -1,1 +1,0 @@
-<iframe src="http://metabase.esp.ce.gov.br/public/dashboard/ad867f63-2183-46c4-a857-d34adfedde84" frameborder="0" width="100%" height="1000px" allowtransparency></iframe>


### PR DESCRIPTION
Quando o agente tentar se inscrever em uma oportunidade, ao inserir seu CPF no campo do tipo 'agente responsável', não permitir que se inscreva se o CPF já estiver vinculado a outro agente.