### PR TITLE
Ajuste na verificação de nota mínima

### DIFF
--- a/Theme.php
+++ b/Theme.php
@@ -279,12 +279,10 @@ class Theme extends BaseV1\Theme{
         $app->hook('POST(opportunity.updateStatusNote)', function() use($app) {
             $app = App::i();
             $opportunity_id = intval($this->postData['id']);
-
             $opportunity = $app->repo('Opportunity')->find($opportunity_id);
+            $minimum_grade = (int) $opportunity->registrationMinimumNote;
 
-            if (!$opportunity) {
-                $this->errorJson(i::__('Oportunidade não encontrada'), 400);
-            }
+            if (!$opportunity) $this->errorJson(i::__('Oportunidade não encontrada'), 400);
 
             $opportunity->checkPermission('@controll');
 
@@ -292,9 +290,7 @@ class Theme extends BaseV1\Theme{
                 $this->errorJson(i::__('Não foi possível alterar a situação de inscrição, pois a oportunidade já foi publicada.'), 400);
             }
 
-            if (empty($opportunity->registrationMinimumNote) && (int)$opportunity->registrationMinimumNote !== 0) {
-                $this->errorJson(i::__('Avaliação para a oportunidade não contém nota mínima'), 400);
-            }
+            if (empty($minimum_grade)) $this->errorJson(i::__('Avaliação para a oportunidade não contém nota mínima.'), 400);
 
             $dql = "SELECT 
                 r.id 

--- a/assets/js/ng.module.applyTechnicalResult.js
+++ b/assets/js/ng.module.applyTechnicalResult.js
@@ -88,10 +88,11 @@
                     }, 1000);
                     
                 }).
-                error(function(error, status){
+                error(function(error, status) {
+                    PNotify.removeAll();
                     new PNotify({
                         title: 'Erro!',
-                        text: 'Ocorreu um erro inesperado',
+                        text: error.data,
                         type: 'error',
                         icon: 'fa fa-exclamation-circle',
                         shadow: true


### PR DESCRIPTION
Ao clicar no botão 'Atualizar status dos candidatos com base na nota mínima', não estava sendo possível atualizar. Foi feito um ajuste na lógica em que qualquer configuração de nota mínima acima de 0 é possível atualizar os status.